### PR TITLE
Create PKGBUILD for telegram-mobile

### DIFF
--- a/PKGBUILDS/phosh/telegram-mobile/PKGBUILD
+++ b/PKGBUILDS/phosh/telegram-mobile/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Sven-Hendrik Haase <svenstaro@gmail.com>
+# Contributor: hexchain <i@hexchain.org>
+# Contributor: ScardracS <marcoscardovi@protonmail.com>
+
+pkgname=telegram-mobile
+pkgver=2.1.13
+pkgrel=1
+pkgdesc='Official Telegram Desktop client'
+arch=('x86_64')
+url="https://desktop.telegram.org/"
+license=('GPL3')
+depends=('hunspell' 'ffmpeg' 'hicolor-icon-theme' 'lz4' 'minizip' 'openal'
+         'qt5-imageformats' 'xxhash' 'libdbusmenu-qt5' 'qt5-es2-wayland')
+makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'gtk3')
+optdepends=('ttf-opensans: default Open Sans font family')
+source=("https://github.com/telegramdesktop/tdesktop/releases/download/v${pkgver}/tdesktop-${pkgver}-full.tar.gz")
+sha512sums=('f28ae7c8c9a9eb8094fc52784742b470235234a3df7487902152858bc7c297b2dcfe5c8b939cdb9653a356b3835609e7289f53cdf7d5fb3f009823d3dbeb1bd8')
+
+build() {
+    cd tdesktop-$pkgver-full
+
+    # export CXXFLAGS="$CXXFLAGS -ffile-prefix-map=$srcdir/tdesktop-$pkgver-full="
+    cmake -B build -G Ninja . \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DTDESKTOP_API_TEST=ON \
+        -DDESKTOP_APP_USE_PACKAGED_RLOTTIE=OFF \
+        -DDESKTOP_APP_USE_PACKAGED_VARIANT=OFF \
+        -DDESKTOP_APP_USE_PACKAGED_GSL=OFF \
+        -DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME=ON \
+        -DTDESKTOP_USE_PACKAGED_TGVOIP=OFF \
+        -DDESKTOP_APP_SPECIAL_TARGET="" \
+        -DTDESKTOP_LAUNCHER_BASENAME="telegramdesktop"
+    ninja -C build
+}
+
+package() {
+    cd tdesktop-$pkgver-full
+    DESTDIR=$pkgdir ninja -C build install
+}


### PR DESCRIPTION
Add qt5-es2-wayland in order to make telegram working. By the way I have changed name to telegram-mobile in order to avoid confusion/conflicts with the original package