### PR TITLE
Add a package for purism's mobile version of geary

### DIFF
--- a/PKGBUILDS/phosh/geary-mobile/PKGBUILD
+++ b/PKGBUILDS/phosh/geary-mobile/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Danct12 <danct12@disroot.org>
+# Contributor: Maxime Gauduin <alucryd@archlinux.org>
+# Contributor: sebikul <sebikul@gmail.com>
+# Contributor: Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
+
+_pkgname=geary
+pkgname=$_pkgname-mobile
+pkgver=3.36.0.4db88830
+pkgrel=0
+pkgdesc='Purism mobile email client for the Phosh desktop'
+arch=(aarch64)
+url='https://source.puri.sm/Librem5/geary'
+license=(GPL3)
+depends=(cairo enchant folks gcr gdk-pixbuf2 glib2 gmime3 gnome-keyring gnome-online-accounts gtk3 iso-codes libcanberra libgee libnotify libytnef libsecret libsoup libxml2 pango sqlite webkit2gtk)
+makedepends=(git gobject-introspection intltool itstool meson vala)
+_commit=4db88830653de2ab2a3cb56543f846245afbf47c
+source=("git+https://source.puri.sm/Librem5/geary.git#commit=$_commit")
+sha512sums=('SKIP')
+provides=("$_pkgname")
+conflicts=("$_pkgname")
+
+build() {
+  arch-meson geary build
+  ninja -C build
+}
+
+package() {
+  DESTDIR="$pkgdir" ninja -C build install
+}


### PR DESCRIPTION
Everything seems to work in portrait at this point with the scale-to-fit script except composing an email, which still takes up a third pane and requires landscape. It definitely works wayyy better than the non-mobile version, but might still make sense to keep on a dev branch until Purism finishes polishing it?

If you wanted to test without having to run the build, I posted the one I made on my pinephone here: http://96.126.108.7:90/pine64/geary-mobile-3.36.0-0-aarch64.pkg.tar.xz

Cheers!