### PR TITLE
pkg: phosh: danctnix-phosh-ui-meta: unbreak gdk xwayland

### DIFF
--- a/PKGBUILDS/phosh/danctnix-phosh-ui-meta/PKGBUILD
+++ b/PKGBUILDS/phosh/danctnix-phosh-ui-meta/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Danct12 <danct12@disroot.org>
 pkgname=danctnix-phosh-ui-meta
 pkgver=0.1
-pkgrel=16
+pkgrel=17
 pkgdesc="Meta package for Phosh"
 arch=(any)
 url="https://github.com/dreemurrs-embedded/Pine64-Arch"
@@ -72,7 +72,7 @@ package() {
 
 md5sums=('7567fd058afb2a7e5c8690fff0291c80'
          '92691718df45090e929219af638898b9'
-         '5a125ec8db04c3eaadd64b913dbca494'
+         '7fc8a933c884cb7cc0bd0dc3656c4fab'
          'b55db963b6aa8e510787eae5cda2e3c2'
          '7d97584f566bb7d50144d75564078e84'
          '69aff19df2d6f54de33d784e760bf6d0'

--- a/PKGBUILDS/phosh/danctnix-phosh-ui-meta/gtk-qt-tweaks.sh
+++ b/PKGBUILDS/phosh/danctnix-phosh-ui-meta/gtk-qt-tweaks.sh
@@ -2,7 +2,7 @@
 
 # Most pure GTK3 apps use wayland by default, but some,
 # like Firefox, need the backend to be explicitely selected.
-export GDK_BACKEND=wayland
+export MOZ_ENABLE_WAYLAND=1
 
 export QT_WAYLAND_DISABLE_WINDOWDECORATION=1
 export QT_QPA_PLATFORM=wayland


### PR DESCRIPTION
Replace GDK_BACKEND=wayland with MOZ_ENABLE_WAYLAND=1. See https://github.com/swaywm/sway/wiki/Running-programs-natively-under-wayland#gtk3

This allows some programs - such as Emacs and Chromium - which aren't Wayland-native to be started with XWayland.