### PR TITLE
Fix paths for two udev rules

### DIFF
--- a/PKGBUILDS/phosh/feedbackd/90-feedbackd.rules
+++ b/PKGBUILDS/phosh/feedbackd/90-feedbackd.rules
@@ -7,6 +7,6 @@ ACTION=="remove", GOTO="feedbackd_end"
 SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT}=="1", ENV{ID_PATH}=="platform-vibrator", TAG+="uaccess", ENV{FEEDBACKD_TYPE}="vibra"
 
 # Front leds of the Librem5
-SUBSYSTEM=="leds", DEVPATH=="*/phone:*:front", ENV{FEEDBACKD_TYPE}="led", RUN+="/usr/libexec/fbd-ledctrl -p %S%p -t pattern -G video"
+SUBSYSTEM=="leds", DEVPATH=="*/phone:*:front", ENV{FEEDBACKD_TYPE}="led", RUN+="/usr/lib/fbd-ledctrl -p %S%p -t pattern -G video"
 
 LABEL="feedbackd_end"

--- a/PKGBUILDS/phosh/feedbackd/90-feedbackd.rules
+++ b/PKGBUILDS/phosh/feedbackd/90-feedbackd.rules
@@ -1,0 +1,12 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of feedbackd.
+
+ACTION=="remove", GOTO="feedbackd_end"
+
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT}=="1", ENV{ID_PATH}=="platform-vibrator", TAG+="uaccess", ENV{FEEDBACKD_TYPE}="vibra"
+
+# Front leds of the Librem5
+SUBSYSTEM=="leds", DEVPATH=="*/phone:*:front", ENV{FEEDBACKD_TYPE}="led", RUN+="/usr/libexec/fbd-ledctrl -p %S%p -t pattern -G video"
+
+LABEL="feedbackd_end"

--- a/PKGBUILDS/phosh/feedbackd/PKGBUILD
+++ b/PKGBUILDS/phosh/feedbackd/PKGBUILD
@@ -8,7 +8,7 @@ arch=('x86_64' 'armv7h' 'aarch64')
 license=('GPL')
 depends=('gobject-introspection' 'gsound' 'json-glib' 'libgudev')
 makedepends=('meson' 'vala')
-source=(https://source.puri.sm/Librem5/$pkgname/-/archive/v$pkgver/$pkgname-v$pkgver.tar.gz)
+source=(https://source.puri.sm/Librem5/$pkgname/-/archive/v$pkgver/$pkgname-v$pkgver.tar.gz 90-feedbackd.rules)
 
 build() {
 	arch-meson ${pkgname}-v${pkgver} output
@@ -17,8 +17,8 @@ build() {
 
 package() {
 	DESTDIR="$pkgdir" ninja -C output install
-	install -Dm644 "$srcdir"/${pkgname}-v${pkgver}/debian/feedbackd.udev \
+	install -Dm644 "$srcdir"/90-feedbackd.rules \
 		"$pkgdir"/usr/lib/udev/rules.d/90-feedbackd.rules
 }
 
-md5sums=('148fa189a5fddf916a88a8415b918f08')
+md5sums=('148fa189a5fddf916a88a8415b918f08' '1897079a2548cf3e02f31d6fd64e1fee')

--- a/PKGBUILDS/pine64/device-pine64-pinephone/20-pinephone-led.rules
+++ b/PKGBUILDS/pine64/device-pine64-pinephone/20-pinephone-led.rules
@@ -4,6 +4,6 @@
 ACTION=="remove", GOTO="pinephone_led_end"
 
 # Setup the front LED for use by feedbackd
-SUBSYSTEM=="leds", DEVPATH=="*/*:indicator", ENV{FEEDBACKD_TYPE}="led", RUN+="/usr/libexec/fbd-ledctrl -p %S%p -t pattern -G video"
+SUBSYSTEM=="leds", DEVPATH=="*/*:indicator", ENV{FEEDBACKD_TYPE}="led", RUN+="/usr/lib/fbd-ledctrl -p %S%p -t pattern -G video"
 
 LABEL="pinephone_led_end"


### PR DESCRIPTION
A line in 20-pinephone-led.rules pointed to a binary in a non-existing path, which led to an error message in the journal. I fixed the path and now the rule executes the binary at the right path.