### PR TITLE
Add btrfs to u-boot

### DIFF
--- a/PKGBUILDS/pine64/uboot-pinephone/PKGBUILD
+++ b/PKGBUILDS/pine64/uboot-pinephone/PKGBUILD
@@ -60,6 +60,7 @@ build() {
   echo 'CONFIG_GZIP=y' >> .config
   echo 'CONFIG_CMD_UNZIP=y' >> .config
   echo 'CONFIG_CMD_EXT4=y' >> .config
+  echo 'CONFIG_CMD_BTRFS=y' >> .config
   echo 'CONFIG_SUPPORT_RAW_INITRD=y' >> .config
   echo 'CONFIG_CMD_EXT4_WRITE=n' >> .config
   echo 'CONFIG_EXT4_WRITE=n' >> .config
@@ -87,6 +88,7 @@ build() {
   echo 'CONFIG_GZIP=y' >> .config
   echo 'CONFIG_CMD_UNZIP=y' >> .config
   echo 'CONFIG_CMD_EXT4=y' >> .config
+  echo 'CONFIG_CMD_BTRFS=y' >> .config
   echo 'CONFIG_SUPPORT_RAW_INITRD=y' >> .config
   echo 'CONFIG_CMD_EXT4_WRITE=n' >> .config
   echo 'CONFIG_EXT4_WRITE=n' >> .config


### PR DESCRIPTION
Thank you for considering this change. I apologize if it does not meet contribution requirements, please point out where I can find the guidelines as I did not see them, and I will fix the pull request.

Adding btrfs config build options to uboot-pinephone so we can boot off of a btrfs partition.

I built and tested this new u-boot build on pinephone braveheart upgraded with: https://pine64.com/product/pinephone-community-edition-3gb-32gb-mainboard-special-offer-for-braveheart-and-ubports-owners/?v=0446c16e2e66

I tested booting both ext4 and btrfs partitions, and it worked like a charm.

I do not have a pinetab to test with, however, I expect it to behave much the same.