### PR TITLE
uboot-pinephone: improve config generation script

### DIFF
--- a/PKGBUILDS/pine64/uboot-pinephone/PKGBUILD
+++ b/PKGBUILDS/pine64/uboot-pinephone/PKGBUILD
@@ -5,7 +5,7 @@ buildarch=8
 
 pkgname=uboot-pinephone
 pkgver=v2020.10_rc3
-pkgrel=3
+pkgrel=4
 pkgdesc="U-Boot for Pine64 - CRUST EDITION"
 arch=('aarch64')
 url='http://www.denx.de/wiki/U-Boot/WebHome'
@@ -23,14 +23,14 @@ source=("u-boot-$_commit_uboot.tar.gz::https://gitlab.com/pine64-org/u-boot/-/ar
         '0001-ATF-set-fno-stack-protector.patch'
         '0001-configs-Add-Pinetab-configuration.patch'
         'boot.txt'
-        'mkscr'
+        'mkubootcfg'
         'scp.bin')
 md5sums=('96ca5597c63d724b245315ca88589a21'
          'ec70813ae71f978f07795cde13ba42c0'
          '348a6943a1c220047ce5312b59da95b6'
          'bdb8e9686df7fccbedf8577a8d3e350a'
          '90caaaf7c972240e2992c5c46102b2e9'
-         '021623a04afd29ac3f368977140cfbfd'
+         '846a082ccd5420f5fc1902d358f6635c'
          'af8268d4f7c026d375e60044fdf12691')
 
 prepare() {
@@ -118,5 +118,6 @@ package() {
   cp u-boot-sunxi-with-spl-pinetab{-624,-552,-492}.bin "${pkgdir}"/boot
   cp u-boot-sunxi-with-spl-pinephone{-624,-552,-492}.bin "${pkgdir}"/boot
 
-  cp ../boot.txt ../mkscr "${pkgdir}"/boot
+  install -Dm755 -t "$pkgdir/usr/bin/" "$srcdir/mkubootcfg"
+  install -Dm600 -t "$pkgdir/boot" "$srcdir/boot.txt"
 }

--- a/PKGBUILDS/pine64/uboot-pinephone/mkscr
+++ b/PKGBUILDS/pine64/uboot-pinephone/mkscr
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ ! -x /usr/bin/mkimage ]]; then
-  echo "mkimage not found. Please install uboot-tools:"
-  echo "  pacman -S uboot-tools"
-  exit 1
-fi
-
-mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d boot.txt boot.scr

--- a/PKGBUILDS/pine64/uboot-pinephone/mkubootcfg
+++ b/PKGBUILDS/pine64/uboot-pinephone/mkubootcfg
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu
+
+mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d /boot/boot.txt /boot/boot.scr

--- a/PKGBUILDS/pine64/uboot-pinephone/uboot-pinephone.install
+++ b/PKGBUILDS/pine64/uboot-pinephone/uboot-pinephone.install
@@ -13,8 +13,8 @@ flash_uboot() {
 ## arg 1:  the new package version
 post_install() {
   echo "Generating U-Boot script"
-  mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d /boot/boot.txt /boot/boot.scr
 
+  mkubootcfg
   flash_uboot
 }
 
@@ -22,7 +22,7 @@ post_install() {
 ## arg 2:  the old package version
 post_upgrade() {
   echo "Re-generating U-Boot script"
-  mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" -d /boot/boot.txt /boot/boot.scr
 
+  mkubootcfg
   flash_uboot
 }


### PR DESCRIPTION
The script is now installed to `/usr/bin`, works when called from any directory, and is also used in the install script to avoid code duplication.