### PR TITLE
Link to install guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains PKGBUILDS that makes Arch Linux ARM runs on mobile.
 
-Currently only supports PinePhone and PineTab. Images for these can be found [here](https://github.com/dreemurrs-embedded/Pine64-Arch/releases).
+Currently only supports PinePhone and PineTab. Images for these can be found [here](https://github.com/dreemurrs-embedded/Pine64-Arch/releases). Instructions for installing are [here](https://github.com/dreemurrs-embedded/Pine64-Arch/wiki/Installation-Guide).
 
 ## Come and talk with us!
  * Discord: https://discord.gg/AvtdRJ3 (#arch-on-mobile)


### PR DESCRIPTION
I think it would be helpful to a new user to link the install instructions instead of letting them find it on the wiki on their own.