### PR TITLE
pkg: danctnix: siglo: upgrade to 0.6.1

### DIFF
--- a/PKGBUILDS/danctnix/siglo/PKGBUILD
+++ b/PKGBUILDS/danctnix/siglo/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Danct12 <danct12@disroot.org>
 pkgname=siglo
-pkgver=0.6.0
+pkgver=0.6.1
 pkgrel=1
 pkgdesc="GTK app to sync InfiniTime watch with PinePhone"
 arch=(any)
 url="https://github.com/alexr4535/siglo"
 license=('MPL')
-depends=(bluez bluez-utils python python-gobject dbus-python python-gatt)
+depends=(bluez bluez-utils python python-gobject dbus-python python-gatt python-requests)
 makedepends=(git meson)
-_commit=677c37a50f1caeeee58ceebab2595542492ec12c # tags/v0.6.0
+_commit=1a297a367741894a30c9cc386b490e287f9b6c65 # tags/v0.6.1
 source=("git+https://github.com/alexr4535/siglo.git#commit=$_commit")
 
 pkgver() {


### PR DESCRIPTION
Update siglo version, and add missing dependency `python-requests`, needed from 0.6.0 onwards