### PR TITLE
pkg: danctnix: siglo: upgrade to 0.6.2

### DIFF
--- a/PKGBUILDS/danctnix/siglo/PKGBUILD
+++ b/PKGBUILDS/danctnix/siglo/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Danct12 <danct12@disroot.org>
 pkgname=siglo
-pkgver=0.6.1
+pkgver=0.6.2
 pkgrel=1
 pkgdesc="GTK app to sync InfiniTime watch with PinePhone"
 arch=(any)
 url="https://github.com/alexr4535/siglo"
 license=('MPL')
-depends=(bluez bluez-utils python python-gobject dbus-python python-gatt python-requests)
+depends=(bluez bluez-utils python python-gobject dbus-python python-gatt python-requests python-pyxdg)
 makedepends=(git meson)
-_commit=1a297a367741894a30c9cc386b490e287f9b6c65 # tags/v0.6.1
+_commit=c19f2f214aa79192255ca32d6176d82c853cfb58 # tags/v0.6.2
 source=("git+https://github.com/alexr4535/siglo.git#commit=$_commit")
 
 pkgver() {


### PR DESCRIPTION
siglo has just updated to 0.6.2, and now has a dependency on pyxdg