### PR TITLE
pkg: pine64: umtp-responder: adding v1.3.6

### DIFF
--- a/PKGBUILDS/pine64/umtp-responder/PKGBUILD
+++ b/PKGBUILDS/pine64/umtp-responder/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Jolly Roberts jolly.development@gmail.com
+pkgname="umtp-responder"
+_pkgname="uMTP-Responder"
+_shortname="umtprd"
+pkgver="1.3.6"
+pkgrel="1"
+pkgdesc="Lightweight USB Media Transfer Protocol (MTP) responder daemon for GNU/Linux"
+arch=('aarch64')
+url="https://github.com/viveris/uMTP-Responder"
+license=('GPLv3')
+source=(
+	"https://github.com/viveris/uMTP-Responder/archive/refs/tags/umtprd-${pkgver}.tar.gz"
+	"alarm-usb-gadget"
+	"alarm-usb-gadget.service"
+	"override.conf"
+	"umtprd.conf"
+	"umtp-responder.service"
+)
+md5sums=(
+	"26bddcafca129b656fb81b100035a9c1"
+	"5c49c4e7572982212c4a64a7d31771cd"
+	"8aa94e8e9b9f17d0a3a90b7b288e2e13"
+	"c51157a0a6661a9887c8f9c2cea65b9d"
+	"8c0f3609aa3cb6ca2d49a4a3a247522c"
+	"0fb24e4fd8fc9e5aa82489846e8c544a"
+)
+prepare=(
+  cp "alarm-usb-gadget" $srcdir/
+  cp "alarm-usb-gadget.service" $srcdir/
+  cp "override.conf" $srcdir/
+  cp "umtprd.conf" $srcdir/
+  cp "umtp-responder.service" $srcdir/
+)
+build(){
+  cd $srcdir/$_pkgname-$_shortname-$pkgver
+  make
+}
+package(){
+  install=umtp-responder.install
+  install -Dm755 alarm-usb-gadget -t $pkgdir/usr/bin
+  install -Dm644 alarm-usb-gadget.service -t $pkgdir/usr/lib/systemd/system
+  install -Dm644 override.conf -t $pkgdir/usr/lib/systemd/system/umtp-responder.service.d
+  install -Dm644 umtprd.conf -t $pkgdir/etc/umtprd
+  install -Dm644 umtp-responder.service -t $pkgdir/usr/lib/systemd/system
+  cd $srcdir/$_pkgname-$_shortname-$pkgver
+  install -Dm755 "$_shortname" -t "$pkgdir/usr/bin"
+}

--- a/PKGBUILDS/pine64/umtp-responder/alarm-usb-gadget
+++ b/PKGBUILDS/pine64/umtp-responder/alarm-usb-gadget
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+CONFIGFS=/sys/kernel/config/usb_gadget/g1
+USB_VENDORID="0x1D6B"  # Linux Foundation
+USB_PRODUCTID="0x0104" # Multifunction composite gadget
+USB_MANUF="Viveris Technologies"
+USB_PRODUCT=`hostnamectl hostname`
+USB_SERIAL=`cat /etc/machine-id`
+
+setup() {
+    # Don't do anything if the USB gadget already exists
+    [ -d $CONFIGFS ] && exit 0
+
+    # Required to make a composite gadget
+    modprobe libcomposite
+
+    # Create all required directories
+    echo "Creating the USB gadget..."
+    mkdir -p $CONFIGFS
+    mkdir -p $CONFIGFS/strings/0x409
+    mkdir -p $CONFIGFS/configs/c.1
+    mkdir -p $CONFIGFS/configs/c.1/strings/0x409
+
+    # Setup IDs and strings
+    echo "Setting up gadget strings..."
+    echo $USB_VENDORID > $CONFIGFS/idVendor
+    echo $USB_PRODUCTID > $CONFIGFS/idProduct
+    echo $USB_MANUF > $CONFIGFS/strings/0x409/manufacturer
+    echo $USB_PRODUCT > $CONFIGFS/strings/0x409/product
+    echo $USB_SERIAL > $CONFIGFS/strings/0x409/serialnumber
+
+    # Create ECM (ethernet) function
+    # echo "Adding ECM function..."
+    # mkdir $CONFIGFS/functions/ecm.usb0
+
+    # Create MTP using FunctionFS
+    echo "Adding MTP function using FunctionFS..."
+    mkdir $CONFIGFS/functions/ffs.mtp
+
+    # Create configuration
+    echo "Creating gadget configuration..."
+    echo "MTP" > $CONFIGFS/configs/c.1/strings/0x409/configuration
+    # ln -s $CONFIGFS/functions/ecm.usb0 $CONFIGFS/configs/c.1
+    ln -s $CONFIGFS/functions/ffs.mtp $CONFIGFS/configs/c.1
+
+    # Mount the MTP FunctionFS
+    echo "Mounting FunctionFS..."
+    mkdir -p /dev/ffs-mtp
+    mount -t functionfs mtp /dev/ffs-mtp
+}
+
+start() {
+    echo "Enabling the USB gadget..."
+    sleep 1
+    UDC=`ls /sys/class/udc`
+    echo "$UDC" > $CONFIGFS/UDC
+}
+
+reset() {
+    echo "Removing the USB gadget..."
+
+    # Remove USB gadget
+    if [ -d $CONFIGFS ]; then
+        echo "Removing gadget configuration..."
+        rm $CONFIGFS/configs/c.1/ffs.mtp
+        # rm $CONFIGFS/configs/c.1/ecm.usb0
+        rmdir $CONFIGFS/configs/c.1/strings/0x409/
+        rmdir $CONFIGFS/configs/c.1/
+        rmdir $CONFIGFS/functions/ffs.mtp
+        # rmdir $CONFIGFS/functions/ecm.usb0
+        rmdir $CONFIGFS/strings/0x409/
+        rmdir $CONFIGFS
+    fi
+
+    # Unmount FunctionFS and delete its mount point
+    if [ -d /dev/ffs-mtp ]; then
+        echo "Unmounting FunctionFS..."
+        umount /dev/ffs-mtp
+        rmdir /dev/ffs-mtp
+    fi
+}
+
+
+case "$1" in
+    reset) reset ;;
+    setup) setup ;;
+    start) start ;;
+    *) ;;
+esac

--- a/PKGBUILDS/pine64/umtp-responder/alarm-usb-gadget.service
+++ b/PKGBUILDS/pine64/umtp-responder/alarm-usb-gadget.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Configure USB gadget
+Before=umtp-responder.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/alarm-usb-gadget setup
+ExecStop=/usr/sbin/alarm-usb-gadget reset
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=umtp-responder.service

--- a/PKGBUILDS/pine64/umtp-responder/override.conf
+++ b/PKGBUILDS/pine64/umtp-responder/override.conf
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/umtprd -conf /etc/umtprd/umtprd.conf
+ExecStartPost=/usr/sbin/alarm-usb-gadget start
+Restart=always

--- a/PKGBUILDS/pine64/umtp-responder/umtp-responder.install
+++ b/PKGBUILDS/pine64/umtp-responder/umtp-responder.install
@@ -1,0 +1,9 @@
+post_install() {
+  systemctl enable alarm-usb-gadget.service
+  systemctl enable umtp-responder.service
+}
+
+post_remove() {
+  systemctl disable alarm-usb-gadget.service
+  systemctl disable umtp-responder.service
+}

--- a/PKGBUILDS/pine64/umtp-responder/umtp-responder.service
+++ b/PKGBUILDS/pine64/umtp-responder/umtp-responder.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Transfer files through the USB port via MTP
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/umtprd
+
+[Install]
+WantedBy=multi-user.target

--- a/PKGBUILDS/pine64/umtp-responder/umtprd.conf
+++ b/PKGBUILDS/pine64/umtp-responder/umtprd.conf
@@ -1,0 +1,57 @@
+#
+# uMTP Responder config file
+# Must be copied to /etc/umtprd/umtprd.conf
+#
+
+# Loop / daemon mode
+# Set to 1 to don't shutdown uMTPrd when the link is disconnected.
+
+loop_on_disconnect 1
+
+#storage command : Create add a storage entry point. Up to 16 entry points supported
+#Syntax : storage "PATH" "NAME"
+
+storage "/"              "System"  "ro"
+storage "/home"          "Home"    "rw"
+#storage "/media/"        "Media"   "rw"
+
+# Set the USB manufacturer string
+
+manufacturer "Viveris Technologies"
+
+# Set the USB Product string
+
+product "uMTP Responder"
+
+# Set the USB Serial number string
+
+serial "01234567"
+
+# Set the USB interface string. Should be always "MTP"
+
+interface "MTP"
+
+# Set the USB Vendor ID, Product ID and class
+
+usb_vendor_id  0x1D6B # Linux Foundation
+usb_product_id 0x0104 # Multifunction composite gadget
+usb_class 0x6         # Image
+usb_subclass 0x1      # Still Imaging device
+usb_protocol 0x1      #
+
+# Device version
+
+usb_dev_version 0x3008
+
+#
+# USB gadget device driver path
+#
+
+usb_functionfs_mode 0x1
+
+usb_dev_path   "/dev/ffs-mtp/ep0"
+usb_epin_path  "/dev/ffs-mtp/ep1"
+usb_epout_path "/dev/ffs-mtp/ep2"
+usb_epint_path "/dev/ffs-mtp/ep3"
+
+usb_max_packet_size 0x200

--- a/PKGBUILDS/pine64/umtp-responder/umtprd.conf
+++ b/PKGBUILDS/pine64/umtp-responder/umtprd.conf
@@ -11,9 +11,9 @@ loop_on_disconnect 1
 #storage command : Create add a storage entry point. Up to 16 entry points supported
 #Syntax : storage "PATH" "NAME"
 
-storage "/"              "System"  "ro"
+# storage "/"              "System"  "ro"
 storage "/home"          "Home"    "rw"
-#storage "/media/"        "Media"   "rw"
+# storage "/media/"        "Media"   "rw"
 
 # Set the USB manufacturer string
 


### PR DESCRIPTION
This is a PKGBUILD to install a umtp-responder (https://github.com/viveris/uMTP-Responder) and some config files.

Based on the Mobian umtp-responder setup. 

- alarm-usb-gadget  
  - bash script to set up the gadget files
- umtprd.conf  
  - config file for the umtprd binary, sets "/" and "/home" as visible. "/" is ReadOnly, "/home" is ReadWrite
- umtp-responder.install  
  - post_install and post_remove enable/disable of the service units 
- alarm-usb-gadget.service  
  - runs the alarm-usb-gadget script before the umtp-responder 
- umtp-responder.service
  - starts the umtprd binary
- override.conf
  - service unit override settings.

Relevant links:
https://github.com/viveris/uMTP-Responder
https://forum.pine64.org/showthread.php?tid=12633
https://gitlab.com/mobian1/issues/-/issues/232

Tested and working on a PinePhone Manjaro Community Edition.
