### PR TITLE
Use more appropriate branding for osk-sdl

### DIFF
--- a/PKGBUILDS/danctnix/osk-sdl/PKGBUILD
+++ b/PKGBUILDS/danctnix/osk-sdl/PKGBUILD
@@ -22,7 +22,10 @@ package() {
 
   # DejaVu is on a different directory than default
   sed -i 's/\/usr\/share\/fonts\/ttf-dejavu/\/usr\/share\/fonts\/TTF/g' ${pkgdir}/etc/osk.conf
-
+  
+  # Change enter key colour
+  sed -i 's/003C00/3584E4/' ${pkgdir}/etc/osk.conf
+  
   # Install initramfs
   install -Dm644 ${srcdir}/osk-sdl-hooks ${pkgdir}/usr/lib/initcpio/hooks/osk-sdl
   install -Dm644 ${srcdir}/osk-sdl-install ${pkgdir}/usr/lib/initcpio/install/osk-sdl


### PR DESCRIPTION
The current enter key colour for osk-sdl is from postmarketOS. The enter key colour I'm proposing is from GNOME, which fits in better with Phosh and distinguishes this from the upstream and it's out of place branding.