### PR TITLE
pn package cleanup

### DIFF
--- a/PKGBUILDS/sxmo/pn/PKGBUILD
+++ b/PKGBUILDS/sxmo/pn/PKGBUILD
@@ -1,12 +1,13 @@
 # Maintainer: dni <office@dnilabs.com>
 pkgname=pn
 pkgver=0.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="libphonenumber command-line wrapper"
 url="https://github.com/Orange-OpenSource/pn"
 arch=('x86_64' 'armv7h' 'aarch64')
-license=('Apache-2.0')
-makedepends=('cmake' 'icu' 'libphonenumber' 'gawk')
+depends=('libphonenumber' 'icu')
+license=('Apache')
+makedepends=('cmake' 'gawk')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 
 build() {


### PR DESCRIPTION
The current version of pn in the repo appears to be built against an old version of icu. While looking into it I decided to fix the errors reported by namcap.