### PR TITLE
Add ttyescape

### DIFF
--- a/PKGBUILDS/danctnix/buffyboard/PKGBUILD
+++ b/PKGBUILDS/danctnix/buffyboard/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Adam Thiede <me@adamthiede.com>
+pkgname=buffyboard
+pkgver=0.2.0
+pkgrel=1
+_lv_drivers_commit="33983bcb0a9bfd0a4cf44dba67617b9f537e76f3"
+_lvgl_commit="a2b555e096f7d401b5d8e877a6b5e81ff81c747a"
+_squeek2lvgl_commit="e3ce01bc38020b21bc61844fa1fed1a4f41097c5"
+pkgdesc="Touch-enabled framebuffer keyboard (not only) for vampire slayers"
+arch=(x86_64 armv7h aarch64)
+url="https://gitlab.com/cherrypicker/buffyboard"
+license=('GPL3')
+depends=(libinput)
+makedepends=(meson libinput libxkbcommon linux-headers udev)
+source=(https://gitlab.com/cherrypicker/buffyboard/-/archive/${pkgver}/buffyboard-${pkgver}.tar.gz
+      https://github.com/lvgl/lv_drivers/archive/${_lv_drivers_commit}.tar.gz
+      https://github.com/lvgl/lvgl/archive/${_lvgl_commit}.tar.gz
+      https://gitlab.com/cherrypicker/squeek2lvgl/-/archive/${_squeek2lvgl_commit}/buffyboard-${_squeek2lvgl_commit}.tar.gz)
+
+build() {
+  mkdir -p "${srcdir}/${pkgname}-${pkgver}/lvgl" "${srcdir}/${pkgname}-${pkgver}/lv_drivers" "${srcdir}/${pkgname}-${pkgver}/squeek2lvgl"
+  mv "${srcdir}/lvgl-${_lvgl_commit}/"* "${srcdir}/${pkgname}-${pkgver}/lvgl"
+  mv "${srcdir}/lv_drivers-${_lv_drivers_commit}/"* "${srcdir}/${pkgname}-${pkgver}/lv_drivers"
+  mv "${srcdir}/squeek2lvgl-${_squeek2lvgl_commit}/"* "${srcdir}/${pkgname}-${pkgver}/squeek2lvgl"
+  arch-meson ${pkgname}-${pkgver} _build
+  meson compile -C _build
+}
+
+package() {
+  DESTDIR=${pkgdir} meson install --no-rebuild -C _build
+}
+
+sha512sums=(
+'6a504ed775ebcc03276b2c10e299e894cdc3ea3c7e40d263e449982dd6ac6a7f37fe2094c84e6d0b92c3f965aefc38e606de66bd74d8d375bb2168acb0c0284e' 
+'788ab2ac810580222e85c580a6e7d94783b6e4a29688274d6eb85ec7e9cbe8c146452baf9b2c8ecde135b9e68539218affd4d3bde40667ed1e2da2fa9b9feea4'
+'6db243760407176d57bc1aafc9145f8f089e6be4b74afff966ca6fbf29605ccd30afbd113412c7259040894eb7506a90a40c07c0e0be1c7bfbaab01c5ea2727c'
+'57fb6bb0445e27c5529f96499f744f64038c549f741ff17a2fc83902e7bdbcf1358c4a3eb37848f89e98d1e6011bb46581ab081bf0b0e01350de2f75e58e2f33')

--- a/PKGBUILDS/danctnix/hkdm/PKGBUILD
+++ b/PKGBUILDS/danctnix/hkdm/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: Adam Thiede <me@adamthiede.com>
+pkgname=hkdm
+pkgver=0.1.8
+pkgrel=1
+pkgdesc="Lighter-weight hotkey daemon"
+url="https://gitlab.com/postmarketOS/hkdm"
+arch=(x86_64 aarch64)
+license=("GPL3")
+source=(https://gitlab.com/postmarketOS/hkdm/-/archive/${pkgver}/hkdm-${pkgver}.tar.gz
+  hkdm.service)
+makedepends=(rust libevdev)
+
+build() {
+  cd ${srcdir}/hkdm-${pkgver}
+  cargo fetch --locked
+  cargo build --frozen --no-default-features --release
+  cargo test --frozen --no-default-features
+}
+
+package() {
+  cd "${srcdir}/hkdm-${pkgver}"
+  install -Dm644 hkdm.example.toml ${pkgdir}/etc/hkdm/config.d/hkdm.example
+  install -Dm755 target/release/hkdm ${pkgdir}/usr/bin/hkdm
+  install -Dm644 ${srcdir}/hkdm.service ${pkgdir}/etc/systemd/system/hkdm.service
+}
+
+sha512sums=(
+"baadb5a21498f3d748dc46a9d0e25204fc3b7965dde2b2d54edc54b8cc48020251ade00a6ee274fe0ea5b824e8fe23f3c5188b0de3ef4227c5fef00120c5a5b8"
+"6e2f6f377e73e2618c14858707ed29cde1ff22614531b33bf3aa825ad7d41c64d69ef8da8db4327813969d9b076d6706df89b6a10c4dace0f29ae6c7f0f456ca"
+)

--- a/PKGBUILDS/danctnix/hkdm/hkdm.service
+++ b/PKGBUILDS/danctnix/hkdm/hkdm.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hotkey Daemon (For) Mobile
+After=multi-user.target
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/bin/hkdm
+
+[Install]
+WantedBy=multi-user.target

--- a/PKGBUILDS/danctnix/ttyescape/PKGBUILD
+++ b/PKGBUILDS/danctnix/ttyescape/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Adam Thiede <me@adamthiede.com>
+pkgname=ttyescape
+pkgver=1.0.2
+pkgrel=1
+pkgdesc="Daemon to allow users to escape to a tty"
+url="https://gitlab.com/postmarketOS/ttyescape"
+arch=(any)
+license=("GPL2")
+depends=(buffyboard terminus-font kbd hkdm)
+
+source=(
+  ${url}/-/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz
+  etc-conf-d-ttyescape.conf
+)
+
+package() {
+  install -Dm755 "${srcdir}/${pkgname}-${pkgver}/togglevt.sh" "${pkgdir}/usr/bin/togglevt.sh"
+
+  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/ttyescape-hkdm.toml" "${pkgdir}/etc/hkdm/config.d/ttyescape.toml"
+
+  install -Dm644 "${srcdir}/etc-conf-d-ttyescape.conf" "${pkgdir}/etc/conf.d/ttyescape.conf"
+}
+
+post_install() {
+  systemctl enable hkdm.service
+}
+
+sha512sums=(
+"844ea5641b83ded3545711ba1560c5acff50e46fd04d5a857c26979cdf83f644f4dfeecdbbb9d520d5147b14c443b9099b6b8097baa814855ee866299a89d95e"
+"1c5a3733be8b4f454dfdd8555049f312ed5bb87e87101303cf445fbbd9ce2b64a5b6131b5b15f5dd5c1ff5c945fb54bb1a58bf8374415c750f88f183530c7c3e"
+)
+

--- a/PKGBUILDS/danctnix/ttyescape/etc-conf-d-ttyescape.conf
+++ b/PKGBUILDS/danctnix/ttyescape/etc-conf-d-ttyescape.conf
@@ -1,0 +1,10 @@
+# tty font to use
+FONT="/usr/share/kbd/consolefonts/ter-128n.psf.gz"
+# Number of times the power button must be pressed whilst volume down
+# is being held to trigger the tty switch
+PRESSCOUNT=3
+# tmpfile to use for counting state
+TMPFILE="/tmp/ttyescape.tmp"
+# define ttys the GUI and TTYescape runs on
+GUIVT="7"
+TTYVT="1"


### PR DESCRIPTION
I'd like to help add TTYescape to Arch. TTYescape is available in PostmarketOS and enables switching to a TTY on the pinephone with hotkeys. The TTY has a touchscreen keyboard. It's pretty useful.
https://wiki.postmarketos.org/index.php?title=TTYescape
https://gitlab.com/postmarketOS/pmaports/-/merge_requests/2309/diffs

I'm not great at PKGBUILDs so these are not working yet. I could use some help. It's based on modified APKBUILDs from Alpine/pmos.

https://pkgs.alpinelinux.org/package/edge/testing/aarch64/hkdm
https://pkgs.alpinelinux.org/package/edge/testing/aarch64/buffyboard
https://pkgs.postmarketos.org/package/master/postmarketos/aarch64/triggerhappy
https://pkgs.postmarketos.org/package/master/postmarketos/aarch64/ttyescape
and the following AUR PKGBUILD:
https://aur.archlinux.org/packages/triggerhappy/