### PR TITLE
Sxmo 1.7

### DIFF
--- a/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
+++ b/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Aren <aren@peacevolution.org>
 
 pkgname=('sxmo-utils' 'sxmo-ui-sway-meta' 'sxmo-ui-dwm-meta')
-pkgver=1.6.0
-pkgrel=2
+pkgver=1.7.1
+pkgrel=1
 pkgdesc="Utility scripts, programs, and configs that hold the Sxmo UI environment together"
 url="https://git.sr.ht/~mil/sxmo-utils"
 arch=('x86_64' 'armv7h' 'aarch64')
@@ -20,16 +20,22 @@ backup=('etc/doas.conf')
 prepare() {
   cd "$pkgname-$pkgver"
 
-  # Use dunst instead because of issues between mako and sxmo-sway on arch
-  sed -i 's@mako@dunst@g' configs/appcfg/sway_template
-
   # Use systemd to start & stop user services
+  # TODO: this should be upstreamed, the new sxmo_daemons (likely in 1.8) script
+  # should make that easier
   sed -e 's@setsid -f mmsdtng@systemctl --user start mmsd-tng.service@g' \
       -e 's@pkill mmsdtng@systemctl --user stop mmsd-tng.service@g' \
       -i scripts/core/sxmo_mmsdconfig.sh
+  sed -i 's/mmsdtng.*/:/' configs/default_hooks/start
+  sed -i '/mmsdtng/d' configs/default_hooks/stop
+  sed -i '/checkmmsd/a return' scripts/modem/sxmo_mms.sh
 
-  # the unclutter executable has a different name on arch than on alpine
-  sed -i 's@unclutter-xfixes@unclutter@g' configs/appcfg/xinit_template
+  sed -e 's/setsid -f vvmd/systemctl --user start vvmd.service/g' \
+      -e 's/pkill \^vvmd/systemctl --user stop vvmd.service/g' \
+      -i scripts/core/sxmo_vvmdconfig.sh
+  sed -i 's/vvmd.*/:/' configs/default_hooks/start
+  sed -i '/vvmd/d' configs/default_hooks/stop
+  sed -i '/checkvvmd/a return' scripts/modem/sxmo_vvm.sh
 
   # Don't start a dbus session when starting sxmo
   sed -i 's@dbus-run-session@@g' scripts/core/sxmo_winit.sh
@@ -59,7 +65,7 @@ package_sxmo-utils() {
     'networkmanager'
     'pn'
     'v4l-utils'
-    'vis'
+    'vvmd'
 
     # Core GUI dependencies
     'sxmo-ui'
@@ -74,10 +80,9 @@ package_sxmo-utils() {
     'nerd-fonts-terminus'
     'sxmo-bemenu')
   optdepends=('codemadness-frontends: Youtube & Reddit scripts'
-              'feh: Set the dwm wallpaper'
               'sfeed: Rss and atom feeds'
               'youtube-dl: Play videos from the web'
-              'w3m')
+              'vis: The default editor')
 
   cd "$pkgname-$pkgver"
 
@@ -87,18 +92,6 @@ package_sxmo-utils() {
   printf %b "options snd slots=,snd-aloop" > "$pkgdir/etc/modprobe.d/sxmo.conf"
 
   make DESTDIR="$pkgdir" install
-
-  # Fix upgrade menu to use pacman
-  sed -i 's@echo "Updating all packages from repositories"@set -e@g' "$pkgdir/usr/bin/sxmo_upgrade.sh"
-  sed -i 's@doas apk update@@g' "$pkgdir/usr/bin/sxmo_upgrade.sh"
-  sed -i 's@apk upgrade@pacman -Syu@g' "$pkgdir/usr/bin/sxmo_upgrade.sh"
-
-  # Fix sxmo_timezonechange.sh to use arch command timedatectl
-  sed -i 's@doas setup-timezone -z@timedatectl set-timezone@g' "$pkgdir/usr/bin/sxmo_timezonechange.sh"
-
-  # Disable management of user daemons to avoid conflicting with systemd
-  sed -i 's@mmsdtng &@:@g' "$pkgdir/usr/share/sxmo/default_hooks/start"
-  sed -i '/checkmmsd/a return' "$pkgdir/usr/bin/sxmo_mms.sh"
 
   # TODO: these should be installe to /usr if possible
   install -Dm644 "$srcdir/rootfs-etc-NetworkManager-conf.d-00-sxmo.conf" "$pkgdir/etc/NetworkManager/conf.d/00-sxmo.conf"
@@ -113,6 +106,9 @@ package_sxmo-utils() {
   # HACK: doas is built without --with-doas-confdir so install the sxmo config directly
   echo "permit :wheel" > "$pkgdir/etc/doas.conf"
   cat "$pkgdir/etc/doas.d/sxmo.conf" >> "$pkgdir/etc/doas.conf"
+
+  # TODO: This fixes a bug in the sxmo build script it should be removed
+  echo "$pkgver" > "$pkgdir/usr/share/sxmo/version"
 
   install -Dm644 "$srcdir/sxmo-setpermissions.service" "$pkgdir/usr/lib/systemd/system/sxmo-setpermissions.service"
 
@@ -135,14 +131,16 @@ package_sxmo-ui-sway-meta() {
            'mako'
            'seatd'
            'slurp'
+           'sway'
            'swaybg'
            'swayidle'
-           'sxmo-sway'
            'wayout'
            'wl-clipboard'
+           'wob'
            'wtype'
            'wvkbd'
            'xorg-xwayland')
+  optdepends=('sxmo-sway: better touch event handling')
 
   install -Dm644 "$pkgbase-$pkgver/configs/applications/swmo.desktop" \
     "$pkgdir/usr/share/wayland-sessions/swmo.desktop"
@@ -156,6 +154,7 @@ package_sxmo-ui-dwm-meta() {
   install=
   depends=('autocutsel'
            'conky'
+           'feh'
            'ttf-dejavu' # for conky
            'otf-latin-modern' # for conky
            'terminus-font' # dmenu & xcalc
@@ -176,13 +175,14 @@ package_sxmo-ui-dwm-meta() {
            'xorg-xrdb'
            'xorg-xset'
            'xorg-xsetroot'
-           'xorg-xwininfo')
+           'xorg-xwininfo'
+           'xprintidle')
 
   install -Dm644 "$pkgbase-$pkgver/configs/applications/sxmo.desktop" \
     "$pkgdir/usr/share/xsessions/sxmo.desktop"
 }
 
-sha512sums=('ef98d0f144d3657d32d5f3e2f78ffef556d72ce7a8b763f050db2f99a26207e27da9702cc533f8bfa255b032077e30c3434d6823b3fca50e5121f98ea7332b92'
+sha512sums=('47d66fd9cd5facbae351596992fe5cb489ccc2f757b3e32f58d6fecbe1ce7331e9c255404c757e59399a3d59580a98fc313e186e58729133b8c6eb6f6634c85d'
             '67a031f309a3232ac1e8abc3fedeaee912c035f9c81b4f709248895905a27ab5844ec92c65e55b79af3894450ba3883549d4004f11efebb47114d41f730e4a5f'
             '6e42f9acc015a21596cdf2d35eb5a80e8fbe97959aabf129861c8e1016bbebad5c706126730515494a0fcb33ad38fd6cd971048d2b5340557a803febf41967a4'
             '4c8f047c4608d89409a44db6370ca225d42e186323f42d0c564edb34f18c84a69a500a89cc2c31d5f0e5c292aa94ea20eaf8213e3e266b8f9e959c3d4ce9fb58'

--- a/PKGBUILDS/sxmo/wob/PKGBUILD
+++ b/PKGBUILDS/sxmo/wob/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Aren <aren@peacevolution.org>
+# Maintainer (aur): Martin Franc <me@martinfranc.eu>
+
+pkgname=wob
+pkgver=0.12
+pkgrel=1
+pkgdesc='A lightweight overlay volume/backlight/progress/anything bar for Wayland'
+arch=('aarch64' 'i686' 'x86_64')
+url='https://github.com/francma/wob'
+license=('ISC')
+depends=('wayland')
+makedepends=('meson' 'wayland-protocols' 'scdoc')
+source=(https://github.com/francma/wob/releases/download/${pkgver}/wob-${pkgver}.tar.gz{,.sig})
+        # "${pkgname}-${pkgver}.tar.gz.sig::https://github.com/francma/wob/releases/download/${pkgver}/wob-${pkgver}.tar.gz.sig")
+validpgpkeys=('5C6DA024DDE27178073EA103F4B432D5D67990E3')
+sha512sums=('a8b0bf5d3b3ade69fa367cef50cb94e3de2fe8fafe99a3f9ab37f7690d89a5bc4adece34df9c79c064f1d0dc203bc2c6785292f725d5c63d6d1e5732c09b38c3'
+            'SKIP')
+
+build() {
+  mkdir -p build
+  arch-meson build "${pkgname}-${pkgver}" -D b_ndebug=true
+  ninja -C build
+}
+
+package() {
+  DESTDIR="${pkgdir}" ninja -C build install
+  install -Dm644 "${pkgname}-${pkgver}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}
+
+check() {
+  ninja -C build test
+}


### PR DESCRIPTION
I've been using this for a while and it seems pretty stable.

The image build script might need a corresponding change because:
 - sxmo-ui-sway-meta now depends on sway instead of sxmo-sway. The patches in sxmo-sway haven't landed, but it is very useful to be able to install other sway versions for testing
 - vis has been changed to an optional dependency, it's still required for the default editor