### PR TITLE
Fix build for evince-mobile

### DIFF
--- a/PKGBUILDS/phosh/evince-mobile/PKGBUILD
+++ b/PKGBUILDS/phosh/evince-mobile/PKGBUILD
@@ -18,14 +18,16 @@ source=("git+https://gitlab.gnome.org/GNOME/evince.git#commit=$_commit"
         'Disable-fullscreen-actions-in-phosh.patch'
         'toolbar-Allow-to-toggle-the-sidebar-button.patch'
         'toolbar-Allow-hiding-zoom-annotation-and-page-widgets.patch'
-        'window-Port-it-to-phones.patch')
+        'window-Port-it-to-phones.patch'
+        'Remove-incorrect-args-for-i18n.merge_file.patch')
 sha256sums=('SKIP'
             '84f300a09dd5435647b1f7837db8f11d149d7add5d62779ed26a03eb35f1444d'
             '194086757f539afc7cd5d24f4bc3e1b16fa321d5cb6c9e27fe0470eb62508098'
             'fa8554c29ef59ad926bc33adead0c4b327cc14c5b444f4fbaa897c76fb67f1c3'
             '3ce259a56cc4f35badbdc142b83c72a4fe1422aeb483979ec343ab8a68a76302'
             '6dbd8d185cd896e1ab772f2aee6147113333109ea8f0e8446335f4da6a9f2bb9'
-            '00413c8f03b75a309c02acb2ab9ea5b52d4f4096994e0bec691fd998c2ed8ef5')
+            '00413c8f03b75a309c02acb2ab9ea5b52d4f4096994e0bec691fd998c2ed8ef5'
+            '5e9690beee8a472148a7c6fda78793a3499d5d0c38e08f61e1589598fab68f1a')
 provides=(libev{document,view}3.so $_pkgname)
 conflicts=($_pkgname)
 depends=(gtk3 libgxps libspectre gsfonts poppler-glib djvulibre t1lib dconf libsecret libsynctex

--- a/PKGBUILDS/phosh/evince-mobile/Remove-incorrect-args-for-i18n.merge_file.patch
+++ b/PKGBUILDS/phosh/evince-mobile/Remove-incorrect-args-for-i18n.merge_file.patch
@@ -1,0 +1,36 @@
+diff --git a/backend/meson.build b/backend/meson.build
+index e44c1d6d74f8c5659a6d2886ba21f5cea91769f5..ab3df9acfeaa7e5b5bd7929261a62ba90f400798 100644
+--- a/backend/meson.build
++++ b/backend/meson.build
+@@ -50,7 +50,6 @@ foreach backend, backend_mime_types: backends
+   )
+ 
+   i18n.merge_file(
+-    appstream,
+     input: appstream_in,
+     output: appstream,
+     po_dir: po_dir,
+diff --git a/data/meson.build b/data/meson.build
+index 8a308b853e5413721455fe57a21cb019292134fa..afc30209833a9d7030f719c45409681b1f655e6a 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -15,7 +15,6 @@ foreach desktop: desktops
+   )
+ 
+   i18n.merge_file(
+-    desktop,
+     type: 'desktop',
+     input: desktop_in,
+     output: desktop,
+diff --git a/meson.build b/meson.build
+index 34c86661f960e971a3211ca1008d9302a85fd511..f74efb3c409b7d1df4eb5029c6ec5182a07bef4c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -492,7 +492,6 @@ install_headers(
+ appdata = ev_namespace + '.appdata.xml'
+ 
+ i18n.merge_file(
+-  appdata,
+   input: appdata + '.in',
+   output: appdata,
+   po_dir: po_dir,


### PR DESCRIPTION
Building `evince-mobile` in a clean chroot fails at the moment. I found the patches in the [gitlab repo](https://gitlab.gnome.org/GNOME/evince/-/commit/1060b24d051607f14220f148d2f7723b29897a54).