### PR TITLE
pkg: danctnix: mmsd-tng: add missing dependency

### DIFF
--- a/PKGBUILDS/danctnix/mmsd-tng/PKGBUILD
+++ b/PKGBUILDS/danctnix/mmsd-tng/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=mmsd-tng
 pkgver=1.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Multimedia Messaging Service Daemon - The Next Generation"
 url="https://gitlab.com/kop316/mmsd"
 arch=('x86_64' 'armv7h' 'aarch64')
 license=("GPL2")
 provides=("mmsd")
 conflicts=("mmsd")
-depends=("c-ares" "mobile-broadband-provider-info" "libmm-glib" "libsoup" "libphonenumber")
+depends=("c-ares" "mobile-broadband-provider-info" "libmm-glib" "libsoup" "libphonenumber" "json-c")
 makedepends=("meson")
 install=mmsd-tng.install
 source=("$pkgname-$pkgver.tar.bz2::https://gitlab.com/kop316/mmsd/-/archive/$pkgver/mmsd-$pkgver.tar.bz2"


### PR DESCRIPTION
In a clean chroot mmsd-tng fails to build. You can verify using `ldd /usr/bin/mmsctl | grep libjson` and `pacman -Ql json-c | grep libjson`.