### PR TITLE
pkg: phosh: phosh: add patch to remove osk button margins

### DIFF
--- a/PKGBUILDS/phosh/phosh/PKGBUILD
+++ b/PKGBUILDS/phosh/phosh/PKGBUILD
@@ -11,6 +11,7 @@ depends=('gtk3' 'libhandy>=1.1.90' 'gnome-desktop' 'gnome-session' 'gnome-shell'
 makedepends=('meson' 'ninja' 'git')
 _commit="f1ad6df16774c97c905b9cdc899a68d12d95ae6b"  # tags/v0.16.0
 source=("phosh::git+https://gitlab.gnome.org/World/Phosh/phosh.git#commit=${_commit}"
+        'osk-button-remove-margins.patch'
         'pam_phosh'
         'sm.puri.OSK0.desktop'
         'phosh.service')
@@ -23,6 +24,8 @@ pkgver() {
 prepare() {
     cd phosh
     git submodule update --init
+
+    patch -p1 < ../osk-button-remove-margins.patch
 }
 
 build() {
@@ -42,6 +45,7 @@ package() {
 }
 
 md5sums=('SKIP'
+         'cf968e048f074d9d3b4854751363bad7'
          '6d5a0d561f8362bf91f85c236a88395d'
          '30c7febb5cbbac40984fb50d66a88639'
          '60c659ae0e643bb63f7fbc484a8d9666')

--- a/PKGBUILDS/phosh/phosh/osk-button-remove-margins.patch
+++ b/PKGBUILDS/phosh/phosh/osk-button-remove-margins.patch
@@ -1,0 +1,25 @@
+Index: phosh-v0.14.1/src/stylesheet/common.css
+===================================================================
+--- phosh-v0.14.1.orig/src/stylesheet/common.css
++++ phosh-v0.14.1/src/stylesheet/common.css
+@@ -32,7 +32,7 @@ phosh-top-panel .indicators {
+   border-radius: 50%;
+   min-width: 0;
+   min-height: 0;
+-  padding: 6px;
++  padding: 11px;
+ }
+ 
+ /*
+Index: phosh-v0.14.1/src/ui/home.ui
+===================================================================
+--- phosh-v0.14.1.orig/src/ui/home.ui
++++ phosh-v0.14.1/src/ui/home.ui
+@@ -51,7 +51,6 @@
+                     <property name="can_focus">True</property>
+                     <property name="halign">end</property>
+                     <property name="valign">center</property>
+-                    <property name="margin-end">6</property>
+                     <property name="receives_default">True</property>
+                     <signal name="clicked" handler="osk_clicked_cb" swapped="true"/>
+                     <style>


### PR DESCRIPTION
Upstream does not seem to care much about the on-screen-keyboard button being hard to hit.
So here is the patch that removes the margins.

See #168 and [here](https://gitlab.gnome.org/World/Phosh/phosh/-/issues/662).