### PR TITLE
sxmo/sxmo-utils: Update and add fixes

### DIFF
--- a/PKGBUILDS/sxmo/sxmo-utils/0002-Fix-appscripts-symlink-destination.patch
+++ b/PKGBUILDS/sxmo/sxmo-utils/0002-Fix-appscripts-symlink-destination.patch
@@ -1,0 +1,25 @@
+From 15b0a1a4baf670d9e62a1c57f4d93cd188c370fa Mon Sep 17 00:00:00 2001
+From: 3np <3np>
+Date: Tue, 22 Feb 2022 22:54:40 +0100
+Subject: [PATCH] Fix appscripts symlink destination
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d88d11a..d088ce9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -70,7 +70,7 @@ install: $(PROGRAMS)
+ 
+ 	# Appscripts
+ 	mkdir -p "$(DESTDIR)$(PREFIX)/share/sxmo/appscripts"
+-	cd scripts/appscripts && find . -name 'sxmo_*.sh' | xargs -I{} ln -fs "$(DESTDIR)$(PREFIX)/bin/{}" "$(DESTDIR)$(PREFIX)/share/sxmo/appscripts/{}" && cd ../..
++	cd scripts/appscripts && find . -name 'sxmo_*.sh' | xargs -I{} ln -fs "$(PREFIX)/bin/{}" "$(DESTDIR)$(PREFIX)/share/sxmo/appscripts/{}" && cd ../..
+ 
+ 	@echo "-------------------------------------------------------------------">&2
+ 	@echo "NOTICE 1: Do not forget to add sxmo-setpermissions to your init system, e.g. for openrc: rc-update add sxmo-setpermissions default && rc-service sxmo-setpermissions start" >&2
+-- 
+2.35.1
+

--- a/PKGBUILDS/sxmo/sxmo-utils/0003-skip-calculating-charge-for-power-devices-without.patch
+++ b/PKGBUILDS/sxmo/sxmo-utils/0003-skip-calculating-charge-for-power-devices-without.patch
@@ -1,0 +1,33 @@
+From 16c5f2174da10b0fc406e137eb2ca0290f0d775c Mon Sep 17 00:00:00 2001
+From: 3np <3np>
+Date: Tue, 22 Feb 2022 21:57:52 +0100
+Subject: [PATCH] skip calculating charge for power devices without
+
+---
+ configs/default_hooks/sxmo_hook_statusbar.sh | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/configs/default_hooks/sxmo_hook_statusbar.sh b/configs/default_hooks/sxmo_hook_statusbar.sh
+index 0cecdc4..79df3be 100644
+--- a/configs/default_hooks/sxmo_hook_statusbar.sh
++++ b/configs/default_hooks/sxmo_hook_statusbar.sh
+@@ -163,9 +163,13 @@ _battery() {
+ 			if [ -e "$power_supply"/capacity ]; then
+ 				PCT="$(cat "$power_supply"/capacity)"
+ 			else
+-				CHARGE_NOW="$(cat "$power_supply"/charge_now)"
+-				CHARGE_FULL="$(cat "$power_supply"/charge_full_design)"
+-				PCT="$(printf "scale=2; %s / %s * 100\n" "$CHARGE_NOW" "$CHARGE_FULL" | bc | cut -d'.' -f1)"
++				if [ -e "$power_supply"/charge_now ]; then
++					CHARGE_NOW="$(cat "$power_supply"/charge_now)"
++					CHARGE_FULL="$(cat "$power_supply"/charge_full_design)"
++					PCT="$(printf "scale=2; %s / %s * 100\n" "$CHARGE_NOW" "$CHARGE_FULL" | bc | cut -d'.' -f1)"
++				else
++					continue
++				fi
+ 			fi
+ 
+ 			BATSTATUS="$(cut -c1 "$power_supply"/status)"
+-- 
+2.35.1
+

--- a/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
+++ b/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=('sxmo-utils' 'sxmo-ui-sway-meta' 'sxmo-ui-dwm-meta')
 pkgver=1.8.2
-pkgrel=2
+pkgrel=3
 _pkgcommit=de71ed7b3400b96d59e4380466c0f9c39272e8d0
 pkgdesc="Utility scripts, programs, and configs that hold the Sxmo UI environment together"
 url="https://git.sr.ht/~mil/sxmo-utils"

--- a/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
+++ b/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Utility scripts, programs, and configs that hold the Sxmo UI environmen
 url="https://git.sr.ht/~mil/sxmo-utils"
 arch=('x86_64' 'armv7h' 'aarch64')
 license=('MIT')
-makedepends=('libx11' 'xorgproto' 'linux-headers' 'busybox')
+makedepends=('libx11' 'xorgproto' 'linux-headers' 'busybox' 'git')
 install=sxmo-utils.install
 source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~mil/sxmo-utils/archive/$_pkgcommit.tar.gz"
         '0001-Let-systemd-handle-service-supervision.patch'

--- a/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
+++ b/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
@@ -13,6 +13,8 @@ makedepends=('libx11' 'xorgproto' 'linux-headers' 'busybox' 'git')
 install=sxmo-utils.install
 source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~mil/sxmo-utils/archive/$_pkgcommit.tar.gz"
         '0001-Let-systemd-handle-service-supervision.patch'
+	'0002-Fix-appscripts-symlink-destination.patch'
+	'0003-skip-calculating-charge-for-power-devices-without.patch'
         'rootfs-etc-NetworkManager-conf.d-00-sxmo.conf'
         'rootfs-etc-polkit-1-rules.d-00-sxmo.rules'
         'rootfs-etc-polkit-1-rules.d-50-org.freedesktop.NetworkManager.rules'
@@ -35,6 +37,8 @@ prepare() {
   sed -i 's/.*vvmd.*/:/' configs/default_hooks/sxmo_hook_start.sh
 
   patch -p1 < '../0001-Let-systemd-handle-service-supervision.patch'
+  patch -p1 < '../0002-Fix-appscripts-symlink-destination.patch'
+  patch -p1 < '../0003-skip-calculating-charge-for-power-devices-without.patch'
 
   # A quick hack becaue $XDG_RUNTIME_DIR contains some files that aren't
   # accessable to the default user, which causes the dialer to fail
@@ -183,6 +187,8 @@ package_sxmo-ui-dwm-meta() {
 
 sha512sums=('e598a4851f889e5d7d48f32c94eff048d864b061ef65e90f004be7657f6807a8b8bb2c75bbccef6a8c68f90da95a22f00f2f548711f95e3f065b6d959389b1f1'
             'abc5ccd74157f1188f2d43370d228a498017cb2a2e17aec131ab34329d95ed76d7323bf1d802754574c26a2463ffe4f426e0ac567e115f581bee8b0bcf9b64cd'
+            'd2f065557cb6e2bd1eb8b16eb67e98724c14f055f921b46f478fca26489ce39dc99ae866b130cd17854782a81f1fc6a07c023b530bb14d46faf877dd3bf36ebc'
+            '0eda21c2ee3f428fecb47322c26d037162ea4fa15020d1110c58a0d141de3aa013a0c2afdf947b2edd704db6dbe411007778751ede63e53767228e79c494a19d'
             '67a031f309a3232ac1e8abc3fedeaee912c035f9c81b4f709248895905a27ab5844ec92c65e55b79af3894450ba3883549d4004f11efebb47114d41f730e4a5f'
             '6e42f9acc015a21596cdf2d35eb5a80e8fbe97959aabf129861c8e1016bbebad5c706126730515494a0fcb33ad38fd6cd971048d2b5340557a803febf41967a4'
             '4c8f047c4608d89409a44db6370ca225d42e186323f42d0c564edb34f18c84a69a500a89cc2c31d5f0e5c292aa94ea20eaf8213e3e266b8f9e959c3d4ce9fb58'

--- a/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
+++ b/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
@@ -4,13 +4,14 @@
 pkgname=('sxmo-utils' 'sxmo-ui-sway-meta' 'sxmo-ui-dwm-meta')
 pkgver=1.8.2
 pkgrel=2
+_pkgcommit=de71ed7b3400b96d59e4380466c0f9c39272e8d0
 pkgdesc="Utility scripts, programs, and configs that hold the Sxmo UI environment together"
 url="https://git.sr.ht/~mil/sxmo-utils"
 arch=('x86_64' 'armv7h' 'aarch64')
 license=('MIT')
-makedepends=('libx11' 'xorgproto' 'linux-headers')
+makedepends=('libx11' 'xorgproto' 'linux-headers' 'busybox')
 install=sxmo-utils.install
-source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~mil/sxmo-utils/archive/$pkgver.tar.gz"
+source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~mil/sxmo-utils/archive/$_pkgcommit.tar.gz"
         '0001-Let-systemd-handle-service-supervision.patch'
         'rootfs-etc-NetworkManager-conf.d-00-sxmo.conf'
         'rootfs-etc-polkit-1-rules.d-00-sxmo.rules'
@@ -19,19 +20,19 @@ source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~mil/sxmo-utils/archive/$pkg
 backup=('etc/doas.conf')
 
 prepare() {
-  cd "$pkgname-$pkgver"
+  cd "$pkgname-$_pkgcommit"
 
   # Use systemd to start & stop user services
   # TODO: this should be upstreamed
   sed -e 's/sxmo_daemons.sh start mmsd.*$/systemctl --user start mmsd-tng.service/g' \
       -e 's/sxmo_daemons.sh stop mmsd/systemctl --user stop mmsd-tng.service/g' \
       -i scripts/core/sxmo_mmsdconfig.sh
-  sed -i 's/.*mmsdtng.*/:/' configs/default_hooks/start
+  sed -i 's/.*mmsdtng.*/:/' configs/default_hooks/sxmo_hook_start.sh
 
   sed -e 's/sxmo_daemons.sh start vvmd.*$/systemctl --user start vvmd.service/g' \
       -e 's/sxmo_daemons.sh stop vvmd/systemctl --user stop vvmd.service/g' \
       -i scripts/core/sxmo_vvmdconfig.sh
-  sed -i 's/.*vvmd.*/:/' configs/default_hooks/start
+  sed -i 's/.*vvmd.*/:/' configs/default_hooks/sxmo_hook_start.sh
 
   patch -p1 < '../0001-Let-systemd-handle-service-supervision.patch'
 
@@ -85,7 +86,7 @@ package_sxmo-utils() {
               'vim: The default editor'
               'yt-dlp: Play videos from the web')
 
-  cd "$pkgname-$pkgver"
+  cd "$pkgname-$_pkgcommit"
 
   mkdir -p "$pkgdir/etc/modules-load.d/"
   printf %b "snd-aloop" > "$pkgdir/etc/modules-load.d/sxmo.conf"
@@ -140,7 +141,7 @@ package_sxmo-ui-sway-meta() {
            'xorg-xwayland')
   optdepends=('sxmo-sway: better touch event handling')
 
-  install -Dm644 "$pkgbase-$pkgver/configs/applications/swmo.desktop" \
+  install -Dm644 "$pkgbase-$_pkgcommit/configs/applications/swmo.desktop" \
     "$pkgdir/usr/share/wayland-sessions/swmo.desktop"
 }
 
@@ -176,11 +177,11 @@ package_sxmo-ui-dwm-meta() {
            'xorg-xwininfo'
            'xprintidle')
 
-  install -Dm644 "$pkgbase-$pkgver/configs/applications/sxmo.desktop" \
+  install -Dm644 "$pkgbase-$_pkgcommit/configs/applications/sxmo.desktop" \
     "$pkgdir/usr/share/xsessions/sxmo.desktop"
 }
 
-sha512sums=('998577f8bb35dde66a0f6054f9d8c3869d2d656318bb43be4e813bb57658a4b949cb39c8e490958104204b45203a4bfc4a27b556273e58a19fa42cc52314968d'
+sha512sums=('e598a4851f889e5d7d48f32c94eff048d864b061ef65e90f004be7657f6807a8b8bb2c75bbccef6a8c68f90da95a22f00f2f548711f95e3f065b6d959389b1f1'
             'abc5ccd74157f1188f2d43370d228a498017cb2a2e17aec131ab34329d95ed76d7323bf1d802754574c26a2463ffe4f426e0ac567e115f581bee8b0bcf9b64cd'
             '67a031f309a3232ac1e8abc3fedeaee912c035f9c81b4f709248895905a27ab5844ec92c65e55b79af3894450ba3883549d4004f11efebb47114d41f730e4a5f'
             '6e42f9acc015a21596cdf2d35eb5a80e8fbe97959aabf129861c8e1016bbebad5c706126730515494a0fcb33ad38fd6cd971048d2b5340557a803febf41967a4'


### PR DESCRIPTION
*  Add upstream changes
* Add `git` as makedepends
* Fix symlink destination for appscripts (without this, building in chroot results in incorrect locations in resulting fs)
* Fix pinephone pro charging status (without this, script will error trying to read non-existing paths for rk818)