### PR TITLE
pkg: phosh: gnome-control-center-mobile: Make power-profiles-daemon optional

### DIFF
--- a/PKGBUILDS/phosh/gnome-control-center-mobile/PKGBUILD
+++ b/PKGBUILDS/phosh/gnome-control-center-mobile/PKGBUILD
@@ -5,7 +5,7 @@
 _pkgname=gnome-control-center
 pkgname=gnome-control-center-mobile
 pkgver=41.4
-pkgrel=1
+pkgrel=2
 pkgdesc="GNOME's main interface to configure various aspects of the desktop - Purism fork"
 url="https://source.puri.sm/Librem5/gnome-control-center"
 license=(GPL2)
@@ -14,14 +14,15 @@ depends=(accountsservice cups-pk-helper gnome-bluetooth gnome-desktop
          gnome-online-accounts gnome-settings-daemon gsettings-desktop-schemas gtk3
          libgtop nm-connection-editor sound-theme-freedesktop upower libpwquality
          gnome-color-manager smbclient libmm-glib libgnomekbd libibus
-         libgudev bolt udisks2 libhandy gsound colord-gtk modemmanager power-profiles-daemon)
+         libgudev bolt udisks2 libhandy gsound colord-gtk modemmanager)
 makedepends=(docbook-xsl git python meson)
 checkdepends=(python-dbusmock python-gobject xorg-server-xvfb)
 optdepends=('system-config-printer: Printer settings'
             'gnome-user-share: WebDAV file sharing'
             'gnome-remote-desktop: screen sharing'
             'rygel: media sharing'
-            'openssh: remote login')
+            'openssh: remote login'
+            'power-profiles-daemon: Power profiles support')
 provides=(gnome-control-center)
 conflicts=(gnome-control-center)
 _commit=d08fac3f0be63f0a4c65d26f47d3b77f8738cfab  # tags/41.4^0


### PR DESCRIPTION
power-profiles-daemon was made an optional component of gnome-control-center in the main Arch package: https://github.com/archlinux/svntogit-packages/commit/d8fc51d2b6adcbd7989591ea7d88f971c01eea1e

I believe it should be made optional here for consistency. It will also allow someone to use tlp instead of power-profiles-daemon if they want to. You can't really use tlp with the current PKGBUILD because you can't uninstall power-profiles-daemon without uninstalling gnome-control-center-mobile and tlp and power-profiles-daemon conflict with each other.

I tried building the package and installing locally.
Testing (Done in Phosh):

1. Opened the Power section of the Settings app. It loaded fine and the  "Power Mode" section was there
2. Uninstalled power-profiles-daemon (masking and stopping it also works).
3. Opened the Power section of the Settings app. It loaded fine and the  "Power Mode" section was gone (as expected since I uninstalled the backing service)
4. Installed power-profiles-daemon
5. Opened the Power section of the Settings app. It loaded fine and the  "Power Mode" section was there

Separately, I was also able to install tlp and get that running.