### PR TITLE
pkg: phosh: gnome-clocks-mobile: make alarms wake from deep sleep

### DIFF
--- a/PKGBUILDS/phosh/gnome-clocks-mobile/PKGBUILD
+++ b/PKGBUILDS/phosh/gnome-clocks-mobile/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Clocks applications for GNOME"
 url="https://wiki.gnome.org/Apps/Clocks"
 arch=(x86_64 armv7h aarch64)
 license=(GPL)
-depends=(gtk3 libgweather gnome-desktop geoclue2 geocode-glib feedbackd libhandy)
+depends=(gtk3 libgweather gnome-desktop geoclue2 geocode-glib feedbackd libhandy waked)
 makedepends=(vala gobject-introspection yelp-tools git meson)
 provides=(gnome-clocks)
 conflicts=(gnome-clocks)
@@ -30,7 +30,8 @@ source=("git+https://gitlab.gnome.org/GNOME/gnome-clocks.git#commit=$_commit"
         '0013-timer-setup-remove-unused-lables.patch'
         '0014-timer-Allow-much-smaller-heights-useing-a-ScrolledWi.patch'
         '0015-alarm-make-ringing-panel-fit-to-small-window-heights.patch'
-        '0016-world-standalone-allow-smaller-window-heights.patch')
+        '0016-world-standalone-allow-smaller-window-heights.patch'
+        'invoke-waked-when-an-alarm-changes.patch')
 sha256sums=('SKIP'
             '4aa66ae47df1d970ed6138e3d3cec7eea588af7dfa39f0940c13dfa5164052ad'
             '9e692d5e340c81943b7312249054a74ee4f83c756a5bf510102a01f5f9ffc458'
@@ -47,7 +48,8 @@ sha256sums=('SKIP'
             '437bf6caa21232c7d8ec40d541ebd443e9343197cd21256e4ce8a1cab6045f6a'
             'bb0121b34c44b0515a9289704e0562871cd5da1544ca520fb04b80baa5c388fe'
             '664515657ee315894be6e1b0b87c9308d9dc1de2eb00aebc29ecf87c133147ac'
-            '992d8868dc96d5b5742cafa26f119484d461a84ee29ac5cf1985ea7f51942d36')
+            '992d8868dc96d5b5742cafa26f119484d461a84ee29ac5cf1985ea7f51942d36'
+            'bf4dcd655839aefe84c6303730aaea50a41cdc40859f21a76a099faa3284a10a')
 
 pkgver() {
   cd $_pkgname

--- a/PKGBUILDS/phosh/gnome-clocks-mobile/invoke-waked-when-an-alarm-changes.patch
+++ b/PKGBUILDS/phosh/gnome-clocks-mobile/invoke-waked-when-an-alarm-changes.patch
@@ -1,0 +1,164 @@
+From f4385bc96e4520c6ef00d124bda41065d5dee266 Mon Sep 17 00:00:00 2001
+From: Robin Westermann <gitlab@seath.de>
+Date: Sat, 27 Feb 2021 14:41:22 +0100
+Subject: [PATCH] invoke waked when an alarm changes
+
+When an alarm is deleted, created, edited or rearmed the service
+waked is notified about the update. So waked can wake the system
+from suspend when an alarm is fired.
+
+Fixes #100
+
+Co-Authored-By: pcworld <0188801@gmail.com>
+[kenchen1368@gmail.com: port to Pine64-Arch]
+[reference: https://gitlab.com/postmarketOS/pmaports/-/issues/1170]
+Co-Authored-By: kclisp <kenchen1368@gmail.com>
+---
+ build-aux/flatpak/org.gnome.clocks.json |  1 +
+ src/alarm-face.vala                     |  2 +
+ src/alarm-item.vala                     | 16 ++++++++
+ src/meson.build                         |  1 +
+ src/waked-utils.vala                    | 53 +++++++++++++++++++++++++
+ 5 files changed, 73 insertions(+)
+ create mode 100644 src/waked-utils.vala
+
+diff --git a/build-aux/flatpak/org.gnome.clocks.json b/build-aux/flatpak/org.gnome.clocks.json
+index 2e015a3..dcd7b5b 100644
+--- a/build-aux/flatpak/org.gnome.clocks.json
++++ b/build-aux/flatpak/org.gnome.clocks.json
+@@ -10,6 +10,7 @@
+         "--socket=fallback-x11",
+         "--socket=wayland",
+         "--socket=pulseaudio",
++        "--system-talk-name=de.seath.Waked",
+         "--share=network",
+         "--system-talk-name=org.freedesktop.GeoClue2",
+         "--filesystem=xdg-run/dconf",
+diff --git a/src/alarm-face.vala b/src/alarm-face.vala
+index 8654e76..73eb7b6 100644
+--- a/src/alarm-face.vala
++++ b/src/alarm-face.vala
+@@ -115,6 +115,7 @@ public class Face : Gtk.Stack, Clocks.Clock {
+                 ((SetupDialog) dialog).apply_to_alarm ();
+                 save ();
+             } else if (response == DELETE_ALARM) {
++                WakedUtils.remove_timer (alarm.id);
+                 alarms.delete_item (alarm);
+                 save ();
+             }
+@@ -124,6 +125,7 @@ public class Face : Gtk.Stack, Clocks.Clock {
+     }
+ 
+     internal void delete (Item alarm) {
++        WakedUtils.remove_timer (alarm.id);
+         alarms.delete_item (alarm);
+         save ();
+     }
+diff --git a/src/alarm-item.vala b/src/alarm-item.vala
+index 6dcb73d..afbc59e 100644
+--- a/src/alarm-item.vala
++++ b/src/alarm-item.vala
+@@ -65,6 +65,20 @@ private class Item : Object, ContentItem {
+             if (_state == value)
+                 return;
+ 
++            switch (value) {
++            case State.DISABLED:
++                WakedUtils.remove_timer (id);
++                break;
++            case State.READY:
++                WakedUtils.update_timer (id, time);
++                break;
++            case State.RINGING:
++                break;
++            case State.SNOOZING:
++                WakedUtils.update_timer (id, (!) snooze_time);
++                break;
++            }
++
+             _state = value;
+             notify_property ("active");
+         }
+@@ -160,6 +174,8 @@ private class Item : Object, ContentItem {
+     public void set_alarm_time (int hour, int minute, Utils.Weekdays? days) {
+       this.days = days;
+       this.time = get_next_alarm_time (hour, minute, days);
++      if (active)
++          WakedUtils.update_timer (id, time);
+     }
+ 
+     private static GLib.DateTime get_next_alarm_time (int hour, int minute, Utils.Weekdays? days) {
+diff --git a/src/meson.build b/src/meson.build
+index e5b0edd..296d524 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -24,6 +24,7 @@ clocks_vala_sources = files(
+   'timer-setup.vala',
+   'timer-setup-dialog.vala',
+   'utils.vala',
++  'waked-utils.vala',
+   'widgets.vala',
+   'window.vala',
+   'world-face.vala',
+diff --git a/src/waked-utils.vala b/src/waked-utils.vala
+new file mode 100644
+index 0000000..9b8fa4a
+--- /dev/null
++++ b/src/waked-utils.vala
+@@ -0,0 +1,53 @@
++/*
++ * Copyright (C) 2021 Robin Westermann <waked@seath.de>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * as published by the Free Software Foundation; either version 2
++ * of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
++ */
++
++namespace Clocks {
++namespace WakedUtils {
++
++    [DBus (name = "de.seath.Waked")]
++    interface Waked : Object {
++        public abstract void add (string id, uint64 time) throws GLib.Error;
++        public abstract void update (string id, uint64 time) throws GLib.Error;
++        public abstract void remove (string id) throws GLib.Error;
++    }
++
++    public void update_timer (string id, GLib.DateTime time) {
++        try {
++            Waked waked = Bus.get_proxy_sync (BusType.SYSTEM, "de.seath.Waked",
++                                                              "/de/seath/Waked/Alarm");
++
++            waked.update (id, time.to_unix ());
++
++        } catch (GLib.Error e) {
++            stderr.printf ("%s\n", e.message);
++        }
++    }
++
++    public void remove_timer (string id) {
++        try {
++            Waked waked = Bus.get_proxy_sync (BusType.SYSTEM, "de.seath.Waked",
++                                                              "/de/seath/Waked/Alarm");
++
++            waked.remove (id);
++
++        } catch (GLib.Error e) {
++            stderr.printf ("%s\n", e.message);
++        }
++    }
++}
++}
+-- 
+2.35.1
+

--- a/PKGBUILDS/phosh/waked/PKGBUILD
+++ b/PKGBUILDS/phosh/waked/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: kclisp <kenchen1368@gmail.com>
+# Contributor: Robin Westermann <waked@seath.de>
+
+pkgname=waked
+pkgver=0.1.1
+pkgrel=1
+pkgdesc="Daemon to let other applications wake up the system"
+url="https://gitlab.com/seath1/waked"
+arch=('x86_64' 'armv7h' 'aarch64')
+license=('GPL2')
+depends=('sdbus-cpp')
+makedepends=('cmake')
+source=(https://gitlab.com/seath1/waked/-/archive/v$pkgver/waked-v$pkgver.tar.gz)
+sha256sums=('56c99a95af55d7b23514945ee71dc19817f024f04f36fdfede48a59928306bd0')
+
+build() {
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -B build -S "$pkgname-v$pkgver/src"
+  make -C build
+}
+
+package() {
+  cd $pkgname-v$pkgver
+  install -Dm755 ../build/waked "$pkgdir"/usr/bin/waked
+  install -Dm644 waked.service "$pkgdir"/usr/lib/systemd/system/waked.service
+  install -Dm644 de.seath.Waked.conf "$pkgdir"/etc/dbus-1/system.d/de.seath.Waked.conf
+}


### PR DESCRIPTION
Adds a patch, ported from
https://git.alpinelinux.org/aports/tree/community/gnome-clocks/0001-waked-implementation.patch

Adds a PKGBUILD for waked

Fixes #100 

</br>

This is my first code contribution to this project and first PKGBUILD, so I'd like a bit of guidance:

1. For waked to be enabled with systemd, you can run (according to upstream):
``` 
systemctl enable waked
systemctl start waked
```

(which should be the same as `systemctl enable --now waked`). Is there anything I can do with this info?

2. waked requires sdbus-cpp, which is available on the AUR (https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=sdbus-cpp), but it doesn't list `aarch64` in its arch. I added it manually, and it seems to work. The PKGBUILD for sdbus-cpp also makes code gen and docs, which seems unnecessary to me. What do you suggest I do here? Make a PKGBUILD under phosh, or see if the maintainer can change it?

Other suggestions and comments are welcome.
 