### PR TITLE
pkg: phosh: gnome-clocks-mobile: allow alarms at same time of day

### DIFF
--- a/PKGBUILDS/phosh/gnome-clocks-mobile/Allow-alarms-to-be-at-the-same-time-of-day-on-differ.patch
+++ b/PKGBUILDS/phosh/gnome-clocks-mobile/Allow-alarms-to-be-at-the-same-time-of-day-on-differ.patch
@@ -1,0 +1,26 @@
+From 60e568e1d5e1119dcd372f52d22c68e08a0bb5c6 Mon Sep 17 00:00:00 2001
+From: kclisp <kenchen1368@gmail.com>
+Date: Tue, 15 Mar 2022 22:33:59 -0400
+Subject: [PATCH] Allow alarms to be at the same time of day on different days
+
+---
+ src/alarm-item.vala | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/alarm-item.vala b/src/alarm-item.vala
+index 6dcb73d..398f537 100644
+--- a/src/alarm-item.vala
++++ b/src/alarm-item.vala
+@@ -232,8 +232,7 @@ private class Item : Object, ContentItem {
+     }
+ 
+     private bool compare_with_item (Item i) {
+-        return (this.time.get_hour () == i.time.get_hour () &&
+-                this.time.get_minute () == i.time.get_minute ());
++        return (this.time.equal (i.time) && i.active);
+     }
+ 
+     public bool check_duplicate_alarm (List<Item> alarms) {
+-- 
+2.35.1
+

--- a/PKGBUILDS/phosh/gnome-clocks-mobile/PKGBUILD
+++ b/PKGBUILDS/phosh/gnome-clocks-mobile/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=gnome-clocks-mobile
 _pkgname=gnome-clocks
 pkgver=41.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Clocks applications for GNOME"
 url="https://wiki.gnome.org/Apps/Clocks"
 arch=(x86_64 armv7h aarch64)
@@ -30,7 +30,8 @@ source=("git+https://gitlab.gnome.org/GNOME/gnome-clocks.git#commit=$_commit"
         '0013-timer-setup-remove-unused-lables.patch'
         '0014-timer-Allow-much-smaller-heights-useing-a-ScrolledWi.patch'
         '0015-alarm-make-ringing-panel-fit-to-small-window-heights.patch'
-        '0016-world-standalone-allow-smaller-window-heights.patch')
+        '0016-world-standalone-allow-smaller-window-heights.patch'
+        'Allow-alarms-to-be-at-the-same-time-of-day-on-differ.patch')
 sha256sums=('SKIP'
             '4aa66ae47df1d970ed6138e3d3cec7eea588af7dfa39f0940c13dfa5164052ad'
             '9e692d5e340c81943b7312249054a74ee4f83c756a5bf510102a01f5f9ffc458'
@@ -47,7 +48,8 @@ sha256sums=('SKIP'
             '437bf6caa21232c7d8ec40d541ebd443e9343197cd21256e4ce8a1cab6045f6a'
             'bb0121b34c44b0515a9289704e0562871cd5da1544ca520fb04b80baa5c388fe'
             '664515657ee315894be6e1b0b87c9308d9dc1de2eb00aebc29ecf87c133147ac'
-            '992d8868dc96d5b5742cafa26f119484d461a84ee29ac5cf1985ea7f51942d36')
+            '992d8868dc96d5b5742cafa26f119484d461a84ee29ac5cf1985ea7f51942d36'
+            'c8d629b2cba3061e3803ae21d7c37fe581c18ae107f8d9ee1e4fca934fb981fa')
 
 pkgver() {
   cd $_pkgname


### PR DESCRIPTION
Fix #326

The faulty patch is 0006-alarms-Make-alarms-persisted-and-add-missed-alarms-n.patch. Purism's patched gnome-clocks probably also has this issue, but I haven't checked.