### PR TITLE
pkg: sxmo: sxmo-utils: Add bc dependency

### DIFF
--- a/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
+++ b/PKGBUILDS/sxmo/sxmo-utils/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=('sxmo-utils' 'sxmo-ui-sway-meta' 'sxmo-ui-dwm-meta')
 pkgver=1.8.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Utility scripts, programs, and configs that hold the Sxmo UI environment together"
 url="https://git.sr.ht/~mil/sxmo-utils"
 arch=('x86_64' 'armv7h' 'aarch64')
@@ -52,6 +52,8 @@ package_sxmo-utils() {
   depends=(
     # Core cli dependencies
     'alsa-utils'
+    'bc' # TODO: Remove in 1.9. sxmo_common.sh not sourced by 
+    #            sxmo_autorotate.sh in 1.8.2, hence no "alias bc=busybox bc".
     'bluez'
     'bluez-utils'
     'busybox'


### PR DESCRIPTION
This adds `bc` as a dependency for sxmo-utils. This is needed because version 1.8.2 does not source sxmo_common.sh, which defines `alias bc=busybox bc`.