### PR TITLE
Add files via upload

### DIFF
--- a/PKGBUILDS/pine64/device-pine64-pinetab/phoc.ini
+++ b/PKGBUILDS/pine64/device-pine64-pinetab/phoc.ini
@@ -1,13 +1,26 @@
-[cursor:seat0]
-map-to-output:DSI-1
+#[core]
+#xwayland=false
 
 [output:DSI-1]
-scale = 1
+scale = 1 
+
+[output:Virtual-1]
+# For the x86 VM using QXL to get a phone like geometry
+modeline = 87.25  720 776 848 976  1440 1443 1453 1493 -hsync +vsync
+mode = 720x1440
+scale = 2
 
 [output:X11-1]
-mode = 1280x720
+mode = 360x720
+#rotate = 90
 scale = 1
 
 [output:WL-1]
-mode = 1280x720
+mode = 360x720
+#rotate = 90
 scale = 1
+
+[output:HEADLESS-1]
+mode = 720x1440
+#rotate = 90
+scale = 2


### PR DESCRIPTION
pkg: pine64: linux-pine64: Pinetab Phoc calls -C /etc/phosh/phoc.ini: failed to parse
phosh.service fails due to bad line, this file replacement fixed boot error, edited for original Pinetab Arch scale = 1