### PR TITLE
pkg: sxmo: sfeed: update to 1.5

### DIFF
--- a/PKGBUILDS/sxmo/sfeed/PKGBUILD
+++ b/PKGBUILDS/sxmo/sfeed/PKGBUILD
@@ -2,19 +2,28 @@
 # Contributor: Caltlgin Stsodaat <contact@fossdaily.xyz>
 
 pkgname=sfeed
-pkgver=1.0
+pkgver=1.5
 pkgrel=1
 pkgdesc='RSS and Atom parser'
-arch=('x86_64' 'armv7h' 'aarch64')
+arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv7h' 'armv6h' 'aarch64')
 url='https://codemadness.org/sfeed-simple-feed-parser.html'
 _url_source='https://codemadness.org/releases/sfeed'
 license=('ISC')
-depends=('sh')
+depends=('sh' 'ncurses')
+optdepends=('curl: sfeed_update script'
+    'xclip: used by sfeed_curses for yanking the URL or enclosure'
+    'xdg-utils: for xdg-open, used by sfeed_curses as a plumber by default'
+    'awk: used by the sfeed_content and sfeed_markread script'
+    'lynx: used by the sfeed_content script to convert HTML content'
+)
+provides=('sfeed-curses')
+conflicts=('sfeed-curses')
 source=("${_url_source}/${pkgname}-${pkgver}.tar.gz")
-sha256sums=('46bf3336046789e5001541588c27af92f517a017d8cd377d0feeb64268e5687a')
+sha256sums=('0a0024bd958b9b00f1b7c29501f1580e3859330102ffd75a8922f50ff8955fd1')
 
 build() {
-  make SFEED_CPPFLAGS="-D_DEFAULT_SOURCE" -C "${pkgname}-${pkgver}"
+  # To change the theme for sfeed_curses you can set SFEED_THEME. See the themes directory for the theme names.
+  make SFEED_CPPFLAGS="-D_DEFAULT_SOURCE" SFEED_THEME="mono" -C "${pkgname}-${pkgver}"
 }
 
 package() {


### PR DESCRIPTION
Update sfeed to latest version from the AUR. Version 1.5 provides `sfeed-curses`, a dependency of the `f_rss` script.