### PR TITLE
pkg: sxmo: wayout: upgrade to 0.1.3

### DIFF
--- a/PKGBUILDS/sxmo/wayout/PKGBUILD
+++ b/PKGBUILDS/sxmo/wayout/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Aren <aren@peacevolution.org>
 
 pkgname=wayout
-pkgver=0.1.2
+pkgver=0.1.3
 pkgrel=1
 pkgdesc="A desktop widget for Wayland desktops"
 arch=('x86_64' 'armv7h' 'aarch64')
@@ -10,7 +10,7 @@ license=('GPL3')
 depends=('wayland' 'pango')
 makedepends=('meson' 'ninja' 'wayland-protocols' 'cairo' 'scdoc')
 source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~proycon/wayout/archive/$pkgver.tar.gz")
-sha512sums=('002874ceb8b91c1541a5f0be402ff4fb702160119624c1f4c0c2a2eeba87d5a2d24d91715c692cb88c2a24a8cf8820f1487c7c74485ab08d4a1febb478d33593')
+sha512sums=('e56af1d8b445569da7751119688479218eeea233620e3bd4ff3b71be05120678568e1987f71d6638c5ca600aebe9dc27231fb8fd1c3d0b9441e1c72f6761ac56')
 
 build() {
   arch-meson build "$pkgname-$pkgver" -Dwerror=false


### PR DESCRIPTION
This version fixes an issue in sxmo where the clock would often be one minute behind.

Tested: building in a clean chroot, and running with the sxmo desktop widget script