### PR TITLE
pkg: sxmo: pn: rebuild

### DIFF
--- a/PKGBUILDS/sxmo/pn/PKGBUILD
+++ b/PKGBUILDS/sxmo/pn/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: dni <office@dnilabs.com>
 pkgname=pn
 pkgver=0.9.0
-pkgrel=3
+pkgrel=4
 pkgdesc="libphonenumber command-line wrapper"
 url="https://github.com/Orange-OpenSource/pn"
 arch=('x86_64' 'armv7h' 'aarch64')


### PR DESCRIPTION
libicu was upgraded, which breaks the current version of pn