### PR TITLE
pkg: danctnix: eg25-manager: upgrade to 0.4.6

### DIFF
--- a/PKGBUILDS/danctnix/eg25-manager/PKGBUILD
+++ b/PKGBUILDS/danctnix/eg25-manager/PKGBUILD
@@ -2,9 +2,9 @@
 # Contributor : Philip Müller <philm@manjaro.org>
 
 pkgname=eg25-manager
-pkgver=0.4.5
+pkgver=0.4.6
 pkgrel=1
-_commit=5b4f9bcc1205c4084049e8e627528e6e6beb3a98
+_commit=e7790f941c053837e596dccd92ba97051a2d4cc1
 pkgdesc="Daemon for managing the Quectel EG25 modem"
 arch=('aarch64')
 url="https://gitlab.com/mobian1/devices/eg25-manager"


### PR DESCRIPTION
This is the third (and hopefully last) update to the udev rules to detect the community firmware.

Smoke test:
 - udev rules are applied to OGPP with community firmware
 - the modem starts