### PR TITLE
pkg: phosh: gnome-contacts-mobile: upgrade to 44.0

### DIFF
--- a/PKGBUILDS/phosh/gnome-contacts-mobile/PKGBUILD
+++ b/PKGBUILDS/phosh/gnome-contacts-mobile/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=gnome-contacts-mobile
 _pkgname=gnome-contacts
-pkgver=43.0
+pkgver=44.0
 pkgrel=1
 pkgdesc="Contacts Manager for GNOME - Forked for Purism patches"
 url="https://wiki.gnome.org/Apps/Contacts"
@@ -15,7 +15,7 @@ depends=(gtk4 folks gnome-online-accounts libgee libadwaita libportal-gtk4
 makedepends=(vala gobject-introspection git meson appstream-glib)
 provides=(gnome-contacts)
 conflicts=(gnome-contacts)
-_commit=0f6c7d65479c54eee54b681836e1ae3c99a9443c  # tags/43.0^0
+_commit=7de4264212aac05f8acec29ba54adac90ae8ed39  # tags/44.0^0
 source=("git+https://gitlab.gnome.org/GNOME/gnome-contacts.git#commit=$_commit"
         '0001-ContactSheet-Add-make-call-and-send-sms-button.patch')
 sha256sums=('SKIP'


### PR DESCRIPTION
Version 44 was had its last release commit 4 days ago. I believe this version should also fixes Issue #532 

For testing, I was able to:
1. View my contacts
2. Edit contact information and have it save the changes
3. Create a new contact
4. Delete a contact
5. Mark a contact as a favorite and have it appear at the top of the list
6. Use the text and call icon to go to the calls and chatty app