### PR TITLE
PineTab2 UCM2 profile

### DIFF
--- a/PKGBUILDS/pine64/alsa-ucm-pinetab2/HiFi.conf
+++ b/PKGBUILDS/pine64/alsa-ucm-pinetab2/HiFi.conf
@@ -1,0 +1,74 @@
+# Based on rk817-sound from the main alsa-ucm-conf package.
+
+If.1 {
+	Condition {
+		Type ControlExists
+		Control "name='Internal Speakers Switch'"
+	}
+
+	True {
+		Define.pbk_mux "HP"
+		SectionDevice."Speaker".EnableSequence [
+			cset "name='Internal Speakers Switch' on"
+		]
+
+		SectionDevice."Speaker".DisableSequence [
+			cset "name='Internal Speakers Switch' off"
+		]
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Internal Speaker"
+
+	EnableSequence [
+		cset "name='Playback Mux' HP"
+		cset "name='Speakers Switch' on"
+	]
+
+	Value {
+		PlaybackMixerElem "Master Playback Volume"
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		# Headphones plugged/unplugged detection is backwards on PT2.
+		# The system sees them as "unplugged" when they are plugged in
+		# and not when they are actually physically unplugged!
+		JackControl "Headphones Jack"
+	}
+
+	ConflictingDevice [
+		"Headphones"
+	]
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "Mic Capture Gain"
+		CaptureMasterElem "Master Capture Volume"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Playback Mux' HP"
+		# Turn off the speaker amps.
+		# (Speaker & headphones have same PlaybackPCM & cannot change output.)
+		cset "name='Speakers Switch' off"
+	]
+
+	Value {
+		PlaybackMixerElem "Master Playback Volume"
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+	}
+
+	ConflictingDevice [
+		"Speaker"
+	]
+}

--- a/PKGBUILDS/pine64/alsa-ucm-pinetab2/HiFi.conf
+++ b/PKGBUILDS/pine64/alsa-ucm-pinetab2/HiFi.conf
@@ -30,10 +30,6 @@ SectionDevice."Speaker" {
 		PlaybackMixerElem "Master Playback Volume"
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId}"
-		# Headphones plugged/unplugged detection is backwards on PT2.
-		# The system sees them as "unplugged" when they are plugged in
-		# and not when they are actually physically unplugged!
-		JackControl "Headphones Jack"
 	}
 
 	ConflictingDevice [
@@ -66,6 +62,7 @@ SectionDevice."Headphones" {
 		PlaybackMixerElem "Master Playback Volume"
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId}"
+		JackControl "Headphones Jack"
 	}
 
 	ConflictingDevice [

--- a/PKGBUILDS/pine64/alsa-ucm-pinetab2/PKGBUILD
+++ b/PKGBUILDS/pine64/alsa-ucm-pinetab2/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: ScottFreeCode <scottfreecode@gmail.com>
+pkgname=alsa-ucm-pinetab2
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="UCM files for PineTab 2"
+arch=(any)
+url="https://github.com/dreemurrs-embedded/Pine64-Arch"
+license=('BSD')
+depends=('alsa-ucm-conf')
+source=(HiFi.conf PineTab2.conf)
+
+package() {
+    install -D -m644 "$srcdir"/PineTab2.conf \
+        "$pkgdir"/usr/share/alsa/ucm2/Pine64/PineTab2/PineTab2.conf
+    install -D -m644 "$srcdir"/HiFi.conf \
+        "$pkgdir"/usr/share/alsa/ucm2/Pine64/PineTab2/HiFi.conf
+    ln -s Pine64/PineTab2 "$pkgdir"/usr/share/alsa/ucm2/PineTab2
+
+    mkdir -p "$pkgdir"/usr/share/alsa/ucm2/conf.d/simple-card
+    ln -sf ../../Pine64/PineTab2/PineTab2.conf \
+        "$pkgdir"/usr/share/alsa/ucm2/conf.d/simple-card/PineTab2.conf
+}
+
+md5sums=('7f0be518e04abae6e06ccae4c817a1b5'
+         '868369d9231c284b50cbed788f80367a')

--- a/PKGBUILDS/pine64/alsa-ucm-pinetab2/PineTab2.conf
+++ b/PKGBUILDS/pine64/alsa-ucm-pinetab2/PineTab2.conf
@@ -1,0 +1,6 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Pine64/PineTab2/HiFi.conf"
+	Comment "Play HiFi quality music"
+}


### PR DESCRIPTION
This solves the problem of the speakers not turning off when the headphone jack is plugged in.

There are some oddities found and worked around, noted in the code.

Code is based on the UCM conf's rk817 profile, with modifications to work around a couple PineTab2 issues. The main outstanding issues are documented in comments next to the workarounds but I also did hardcode the playback mux to HP removing the SPK option as SPK seemed to disable sound in practice.

Packaging is based on alsa-ucm-pinetab.