### PR TITLE
Fix links in pacman.conf

### DIFF
--- a/misc/pacman.conf.aarch64
+++ b/misc/pacman.conf.aarch64
@@ -72,10 +72,10 @@ LocalFileSigLevel = Optional
 # DANCTNIX: Uncomment this if you want to be the first trying out new stuffs.
 # They might break your device.
 #[danctnix-testing]
-#Server = https://p64.arikawa-hi.me/aarch64/danctnix-testing/
+#Server = https://p64.arikawa-hi.me/danctnix-testing/aarch64/
 
 [danctnix]
-Server = https://p64.arikawa-hi.me/aarch64/danctnix/
+Server = https://p64.arikawa-hi.me/danctnix/aarch64/
 
 [core]
 Server = http://mirror.archlinuxarm.org/aarch64/core/


### PR DESCRIPTION
Without this I have the following error:
```
:: Synchronizing package databases...
 danctnix-testing.db failed to download
 danctnix.db failed to download
 core is up to date
 extra is up to date
 alarm is up to date
error: failed retrieving file 'danctnix-testing.db' from p64.arikawa-hi.me : The requested URL returned error: 404
error: failed retrieving file 'danctnix.db' from p64.arikawa-hi.me : The requested URL returned error: 404
error: failed to synchronize all databases (unexpected error)
```