### PR TITLE
New package: auto lock the attached keyboard when flipped behind tablet

### DIFF
--- a/PKGBUILDS/pine64/acpi-kbd-autolock-pinetab2/PKGBUILD
+++ b/PKGBUILDS/pine64/acpi-kbd-autolock-pinetab2/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: ScottFreeCode <scottfreecode@gmail.com>
+pkgname=acpi-kbd-autolock-pinetab2
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Automatically turn off the hardware/case keyboard when it is flipped shut (or behind the tablet), for the PineTab 2"
+arch=(any)
+url="https://github.com/dreemurrs-embedded/Pine64-Arch"
+license=('BSD')
+depends=('acpid')
+source=(lid toggle-keyboard.sh)
+
+package() {
+    install -D -m644 "$srcdir"/lid \
+        "$pkgdir"/etc/acpi/events/lid
+    install -D -m755 "$srcdir"/toggle-keyboard.sh \
+        "$pkgdir"/etc/acpi/toggle-keyboard.sh
+}
+
+post_install() {
+    systemctl enable --now acpid
+}
+
+md5sums=('fdac6076a6c9cf9e3fad89302fc06cf9'
+         'c8862783b76c9addf604ba095c9814b4')

--- a/PKGBUILDS/pine64/acpi-kbd-autolock-pinetab2/lid
+++ b/PKGBUILDS/pine64/acpi-kbd-autolock-pinetab2/lid
@@ -1,0 +1,2 @@
+event=button/lid
+action=/etc/acpi/toggle-keyboard.sh %e

--- a/PKGBUILDS/pine64/acpi-kbd-autolock-pinetab2/toggle-keyboard.sh
+++ b/PKGBUILDS/pine64/acpi-kbd-autolock-pinetab2/toggle-keyboard.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+ACTION=bind
+MESSAGE=on
+if [[ "$3" = "close" ]]
+then
+	ACTION=unbind
+	MESSAGE=off
+fi
+
+KEYBOARD=4-1
+#KEYBOARD=`grep -r --include=uevent Touchpad /sys/devices/ | cut -d/ -f7 | grep -v : | sort | uniq`
+
+echo "$KEYBOARD" > /sys/bus/usb/drivers/usb/"$ACTION"
+
+for user in `who | cut -f1 -d\  | sort | uniq`
+do
+	sudo -u "$user" DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/"`id -u $user`"/bus \
+		notify-send -a 'PineTab2 case' "Keyboard turned $MESSAGE."
+done


### PR DESCRIPTION
This is something that we get a lot of requests for routinely.

It's not 100% foolproof or 100% theoretically complete, but it's about as good as it seems likely to get at the moment.

## Some CAVEATS:

- The "lid close" event it relies upon doesn't fire _100%_ of the time for some reason. This means:
  - When putting folding the case back to use the tablet in, well, tablet style, make sure you see the keyboard off popup/notification.
  - You should still lock your screen before closing the case. NOTE: You should do that anyway because disabling the keyboard means the screen can't press the keys, but doesn't mean the keys can't tap the screen!
- The "hinge" on the case is floppy enough that the keyboard can slide to one side or the other far enough that it is no longer detected as "closed" and the keyboard comes back on. This should pop up a notification alerting you, however.
- If you boot (or wake from hibernate?) and the keyboard is already flipped back, the keyboard will still be on initially.

TL;DR:

- You should still lock your screen before closing the case.
- Pay attention to the keyboard on/off notification.

## Initial Boot issue

This should really also fire the event or perform the equivalent action when the system starts (including from hibernate if necessary) and the keyboard is already flipped.

In terms of when, we'll want to do this either with a cron job and the `@reboot` schedule keyword, or by creating and enabling a systemd service that runs once. And _maybe_ (if the other method doesn't work for coming out of hibernate) also check out systemd's support for hooks related to suspend/sleep/hibernate.

In terms of how, on the other hand, we have a conundrum. I can't find how to query the system for the state of the lid / hall sensor. The internet just says to look for the lid in `/proc/acpi/…` but the PineTab2 doesn't have that. The event does seem to fire on wake from sleep, so, maybe it _should_ fire on boot but either it doesn't or it's somehow too early before USB is ready to be disabled. Or maybe we really do need to be able to find out on-demand, not from an event, what the state is. Someone more familiar with what the device tree is defining for the hall sensor and lid may need to take a look and tell us if this is possible or would be with the right tweaks (I mean, theoretically Linux _should_ be able to read the current gpio state of the sensor _somehow_…).

## Virtual/Onscreen Keyboard

It would be nice to toggle the onscreen/virtual keyboard so when the attachment keyboard is not available the touchscreen keyboard is. However, this poses several problems:

- Surely it should also turn back on when the keyboard is detached. While we _can_ receive an event for switching in and out of "tablet mode" i.e. the keyboard detaching, this is arguably a different event/action category?
- How to disable/enable the onscreen keyboard may depend on the desktop environment and/or the keyboard program.
- Some users may want the onscreen keyboard enabled even with the hardware keyboard attached and enabled. Either they should be able to configure it not to turn off the virtual keyboard or they should be able to not install that part.
- Other users may want the onscreen keyboard disabled even with the hardware keyboard flipped back, they may prefer to flip the keyboard and use it when needed rather than ever activating the onscreen keyboard. (Arguably this can also be achieved by selecting "None" for the virtual keyboard or, if there are _no_ circumstances in which they are wanted, uninstalling them all. But maybe that's extreme or unhelpful in other contexts when it would still be good to be able to tap the tray icon and turn it on.)
- Any of that might depend which desktop environment they're using, e.g. I might want the onscreen keyboard in Plasma but not in Phosh.
- There's a tray icon you can tap to turn the virtual keyboard on or off manually.

The long and short of which is that it would make a lot more sense to _offer enabling/disabling the virtual/onscreen keyboard as a separate package or family of packages_, if it's truly needed vs. the manual option; it's either going to take a lot of variants or a lot of configuring, and _none of it needs to touch the functionality of disabling/enabling the attached keyboard._
