### PR TITLE
Use pipewire-session-manager instead of pipewire-media-session

### DIFF
--- a/PKGBUILDS/plasma/plasma-mobile-settings/PKGBUILD
+++ b/PKGBUILDS/plasma/plasma-mobile-settings/PKGBUILD
@@ -3,12 +3,12 @@
 
 pkgname=plasma-mobile-settings
 pkgver=20221014
-pkgrel=2
+pkgrel=3
 arch=('any')
 url="https://gitlab.manjaro.org/manjaro-arm/packages/community/plasma-mobile/$pkgname"
 license=('GPL')
 pkgdesc='Settings files for Plasma Mobile'
-depends=('accountsservice' 'noto-fonts' 'breeze' 'breeze-gtk' 'pipewire' 'pipewire-media-session' 'hfd-service'
+depends=('accountsservice' 'noto-fonts' 'breeze' 'breeze-gtk' 'pipewire' 'pipewire-session-manager' 'hfd-service'
          'modemmanager' 'systemd')
 makedepends=('git')
 install=$pkgname.install

--- a/PKGBUILDS/plasma/plasma-mobile/PKGBUILD
+++ b/PKGBUILDS/plasma/plasma-mobile/PKGBUILD
@@ -4,13 +4,13 @@
 
 pkgname=plasma-mobile
 pkgver=5.27.6
-pkgrel=1
+pkgrel=2
 pkgdesc="General UI components for Plasma Phone including shell, containment and applets."
 arch=('aarch64' 'x86_64')
 url="https://community.kde.org/Plasma/Mobile"
 license=('GPL3')
 depends=('desktop-file-utils' 'plasma-workspace' 'networkmanager-qt' 'modemmanager-qt' 'kpeople' 'telepathy-qt'
-         'libphonenumber' 'plasma-wayland-session' 'pipewire-media-session' 'kirigami-addons')
+         'libphonenumber' 'plasma-wayland-session' 'pipewire-session-manager' 'kirigami-addons')
 makedepends=('cmake' 'baloo' 'extra-cmake-modules' 'kdoctools')
 replaces=('plasma-phone-components')
 source=("https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz")


### PR DESCRIPTION
`pipewire-media-session` is a legacy pipewire session manager. Packages in official repository usually depend on `pipewire-session-manager`. Yes, names are similar, but the later one is not a real package, it's what `pipewire-media-session` and `wireplubmer` provides. So this way users will be able to use any session manager (legacy or `wireplubmer`).