### PR TITLE
Try to fix Pinetab display issues

### DIFF
--- a/PKGBUILDS/pine64/linux-megi/PKGBUILD
+++ b/PKGBUILDS/pine64/linux-megi/PKGBUILD
@@ -6,7 +6,7 @@ buildarch=8
 pkgbase=linux-megi
 _desc="Megous Kernel"
 pkgver=6.4.1
-pkgrel=1
+pkgrel=2
 arch=('aarch64')
 url="https://github.com/megous/linux"
 license=('GPL2')
@@ -34,6 +34,7 @@ source=("linux-$_commit.tar.gz::https://github.com/megous/linux/archive/${_commi
         'pinetab-accelerometer.patch'
         '0002-dts-add-pinetab-dev-old-display-panel.patch'
         'dts-pinetab-make-audio-routing-consistent-with-pinephone.patch'
+	'dts-pinetab-fix-display.patch'
         # Bootsplash
         '0002-revert-fbcon-remove-now-unusued-softback_lines-cursor-argument.patch'
         '0003-revert-fbcon-remove-no-op-fbcon_set_origin.patch'
@@ -263,6 +264,7 @@ md5sums=('f2eaa521ceba559e3b61c18ed77a56ca'
          'd0fd6bd627223d4c9fc001ffff9df401'
          '3182f25beb0b76e8abd2e9de8213351d'
          '60e9d1ccba52bd2634fbe8034b110e36'
+         '1b4ea887c298871812dee1771e59d7f6'
          'a31a435ab6cd8e7a47601159d665ce50'
          'fed6ae4ac4c3f56178fa4aca6c934d6f'
          'ee3fad8e3468bba539a42ee3ed2b488f'

--- a/PKGBUILDS/pine64/linux-megi/dts-pinetab-fix-display.patch
+++ b/PKGBUILDS/pine64/linux-megi/dts-pinetab-fix-display.patch
@@ -1,0 +1,14 @@
+--- a/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c	2023-07-01 20:46:40.000000000 +0000
++++ b/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c	2023-08-08 23:47:37.069526508 +0000
+@@ -919,7 +919,10 @@
+ 	dsi->format = MIPI_DSI_FMT_RGB888;
+ 	dsi->lanes = 4;
+ 
+-	return mipi_dsi_attach(dsi);
++	ret =  mipi_dsi_attach(dsi);
++	if (ret)
++		drm_panel_remove(&ctx->panel);
++	return ret;
+ }
+ 
+ static void ili9881c_dsi_remove(struct mipi_dsi_device *dsi)


### PR DESCRIPTION
This includes the [0014-pinetab-dsi-from-raspeberrypi.patch](https://gitlab.com/postmarketOS/pmaports/-/merge_requests/3963/diffs#12cd9543739781bff419f26c50037f63e619325e) from a postmarketOS MR to try and fix the same  Pinetab display issues encountered in kernels 5.10+. 

Trying it myself, it seems to solve them. I've fully shut off and powered it back on multiple times without any of the odd blank screen issues encountered before.

I noticed a [Mobian MR](https://salsa.debian.org/Mobian-team/devices/kernels/sunxi64-linux/-/issues/85) open for this issue too, but this more minor patch seems to get my Pinetab going at least. 

This should hopefully fix #370 

I have a compiled version available for testing [here](https://github.com/aqtrans/Pine64-Arch/releases/download/6.1-patched/linux-megi-6.4.1-1-aarch64.pkg.tar.xz), but note that I'd commented out the bootspash and dev-edition patches, as I seemingly had an unclean src/ (compiling with this PR, all patches applied without issue), but it is what I have been testing with.