### PR TITLE
pkg: phosh: danctnix-phosh-ui-meta: use gnome-control-center-mobile

### DIFF
--- a/PKGBUILDS/phosh/danctnix-phosh-ui-meta/PKGBUILD
+++ b/PKGBUILDS/phosh/danctnix-phosh-ui-meta/PKGBUILD
@@ -15,7 +15,7 @@ depends=(
 	feedbackd
 	squeekboard
 	dnsmasq
-	gnome-control-center
+	gnome-control-center-mobile
 	sound-theme-librem5
 	iio-sensor-proxy
 	wys


### PR DESCRIPTION
Noticed that it points to wrong package. Should you this one: https://github.com/dreemurrs-embedded/Pine64-Arch/tree/master/PKGBUILDS/phosh/gnome-control-center-mobile