### PR TITLE
Fix deprecated kernel parameters

### DIFF
--- a/PKGBUILDS/pine64/device-pine64-pinephonepro/boot.txt
+++ b/PKGBUILDS/pine64/device-pine64-pinephonepro/boot.txt
@@ -31,7 +31,7 @@ else
         setenv bootdir "/boot"
 fi
 
-setenv bootargs loglevel=4 console=ttyS2,115200 console=tty0 root=/dev/mmcblk${linux_mmcdev}p${rootpart} rw rootwait quiet bootsplash.bootfile=bootsplash-themes/danctnix/bootsplash
+setenv bootargs loglevel=4 console=ttyS2,115200 console=tty0 cryptdevice=/dev/mmcblk${linux_mmcdev}p${rootpart}:root root=/dev/mapper/root rw rootwait quiet bootsplash.bootfile=bootsplash-themes/danctnix/bootsplash
 
 echo "Loading kernel..."
 load mmc ${devnum}:1 ${ramdisk_addr_r} ${bootdir}/Image.gz

--- a/PKGBUILDS/pine64/uboot-pinephone/boot.txt
+++ b/PKGBUILDS/pine64/uboot-pinephone/boot.txt
@@ -16,7 +16,7 @@ else
 	setenv bootdir "/boot"
 fi
 
-setenv bootargs loglevel=4 console=${console} console=tty0 root=/dev/mmcblk${linux_mmcdev}p${rootpart} rw rootwait quiet bootsplash.bootfile=bootsplash-themes/danctnix/bootsplash
+setenv bootargs loglevel=4 console=${console} console=tty0 cryptdevice=/dev/mmcblk${linux_mmcdev}p${rootpart}:root root=/dev/mapper/root rw rootwait quiet bootsplash.bootfile=bootsplash-themes/danctnix/bootsplash
 
 echo "Loading kernel..."
 load mmc ${mmc_bootdev}:1 ${ramdisk_addr_r} ${bootdir}/Image.gz

--- a/PKGBUILDS/pine64/uboot-pinetab2/boot.txt
+++ b/PKGBUILDS/pine64/uboot-pinetab2/boot.txt
@@ -14,7 +14,7 @@ else
 	setenv bootdir "/boot"
 fi
 
-setenv bootargs loglevel=4 root=/dev/mmcblk${linux_mmcdev}p${rootpart} rw rootwait
+setenv bootargs loglevel=4 cryptdevice=/dev/mmcblk${linux_mmcdev}p${rootpart}:root root=/dev/mapper/root rw rootwait
 
 echo "Loading kernel..."
 load mmc ${devnum}:1 ${ramdisk_addr_r} ${bootdir}/vmlinuz-linux-pinetab2


### PR DESCRIPTION
Fixes the error message descibed in https://github.com/dreemurrs-embedded/Pine64-Arch/issues/589. I tested it with my Pinephone and it worked. I don't have the other devices, but I think it should work similarly.

In order to get my phone to boot, I additionally had to change the following line in my `/etc/mkinitcpio.conf` from:
`HOOKS=(base udev autodetect modconf block filesystems keyboard osk-sdl fsck bootsplash-danctnix)`
to
`HOOKS=(base udev keyboard keymap osk-sdl autodetect modconf kms block encrypt filesystems fsck)`.

Then I ran 
`mkinitcpio -P`
and
```
cd /boot/
./mkscr
```
I am not sure how or if the `mkinitcpio.conf` should be updated.