### PR TITLE
sxmo: use autologin with tinydm

### DIFF
--- a/PKGBUILDS/sxmo/autologin/0001-Direct-logs-to-process-stdout.patch
+++ b/PKGBUILDS/sxmo/autologin/0001-Direct-logs-to-process-stdout.patch
@@ -1,0 +1,27 @@
+From dcc463f9331e3423839649c88efebc6f3b296f7f Mon Sep 17 00:00:00 2001
+From: Aren Moynihan <aren@peacevolution.org>
+Date: Sun, 29 Oct 2023 14:34:31 -0400
+Subject: [PATCH] Direct logs to process stdout
+
+This makes it possible to get logs from the graphical session in
+the system log, instead of losing them to the tty.
+---
+ main.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/main.c b/main.c
+index 0055fad..3ab0ea9 100644
+--- a/main.c
++++ b/main.c
+@@ -51,8 +51,6 @@ static void setup_vt(int vt) {
+ 	int fd = check_errno("open tty", open(p, O_RDWR));
+ 
+ 	check_errno("dup2", dup2(fd, 0));
+-	check_errno("dup2", dup2(fd, 1));
+-	check_errno("dup2", dup2(fd, 2));
+ 
+ 	struct vt_mode mode = { 0 };
+ 	mode.mode = VT_AUTO;
+-- 
+2.42.0
+

--- a/PKGBUILDS/sxmo/autologin/PKGBUILD
+++ b/PKGBUILDS/sxmo/autologin/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Aren <aren@peacevolution.org>
+# Contributor: Jakob Kukla <jakob [dot] kukla [at] gmail [dot] com>
+
+pkgname=autologin
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="No-fuzz automatic login"
+arch=(x86_64 aarch64)
+url="https://git.sr.ht/~kennylevinsen/autologin"
+license=('GPL3')
+depends=('pam')
+makedepends=('meson' 'ninja')
+backup=('etc/pam.d/autologin')
+source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~kennylevinsen/autologin/archive/$pkgver.tar.gz"
+        "0001-Direct-logs-to-process-stdout.patch"
+        "autologin.pam")
+sha256sums=('eb084620e660c3d1708beb58cd3520220ad05b5f628378c3118c36379b33221a'
+            'f11321beb8cf34ee8fb4efb67a994bfffd110958e3941d1e838527e3b0791f96'
+            '99cd77f21ee44a0c5e57b0f3670f711a00496f198fc5704d7e44f5d817c81a0f')
+
+prepare() {
+  cd "$pkgname-$pkgver"
+
+  patch -p1 < "../0001-Direct-logs-to-process-stdout.patch"
+}
+
+build() {
+  arch-meson $pkgname-$pkgver build
+  ninja -C build
+}
+
+package() {
+  DESTDIR="$pkgdir" ninja -C build install
+
+  install -Dm644 "$srcdir/$pkgname-$pkgver/autologin.service" \
+    "$pkgdir/usr/lib/systemd/system/autologin.service"
+
+  install -Dm644 "$srcdir/autologin.pam" \
+    "$pkgdir/etc/pam.d/autologin"
+}

--- a/PKGBUILDS/sxmo/autologin/autologin.pam
+++ b/PKGBUILDS/sxmo/autologin/autologin.pam
@@ -1,0 +1,8 @@
+#%PAM-1.0
+
+auth       required     pam_securetty.so
+auth       requisite    pam_nologin.so
+auth       include      system-local-login
+account    include      system-local-login
+session    include      system-local-login
+password   include      system-local-login

--- a/PKGBUILDS/sxmo/tinydm/PKGBUILD
+++ b/PKGBUILDS/sxmo/tinydm/PKGBUILD
@@ -2,16 +2,16 @@
 
 pkgname=tinydm
 pkgver=1.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Tiny wayland / x11 session starter for single user machines"
 arch=('x86_64' 'armv7h' 'aarch64')
 url="https://gitlab.com/postmarketOS/tinydm"
 license=('GPL3')
-depends=('xorg-xinit')
+depends=('xorg-xinit' 'autologin')
 source=("$pkgname-$pkgver.tar.bz2::https://gitlab.com/postmarketOS/tinydm/-/archive/$pkgver/tinydm-$pkgver.tar.bz2"
         "tinydm.service")
 sha512sums=('81279224c062d01aa81b08804d9e753599f92d756ff2ef9012b585f44598a1f26122be653872e8c97dd8a1cbed7cc213f7f56ea284d370e5884506f01b1c1e0b'
-            '5c67471bce07adfaec6927717aaf137aec1bbc92f659848f6d6714cd3ef84bbcf1a1c2369cef593b5194a50181127756d1554bb952f562c8cad3a881aeed46f2')
+            '577032bb608d594097770dc773884d7ab52dab9748cbcf658122bcb9b155c430ff183850a227d39f845726030aa47089fc63c08f9303b00d4425dbf54767af19')
 
 prepare() {
   cd "$pkgname-$pkgver"

--- a/PKGBUILDS/sxmo/tinydm/tinydm.service
+++ b/PKGBUILDS/sxmo/tinydm/tinydm.service
@@ -1,48 +1,20 @@
 [Unit]
 Description=Tiny wayland / x11 session starter for single user machines
-
-# replaces the getty
+After=systemd-user-sessions.service plymouth-quit-wait.service
+After=getty@tty1.service
 Conflicts=getty@tty1.service
-After=getty@tty1.service dbus.socket
-
-# Needs all the dependencies of the services it's replacing
-# (currently getty@tty1.service):
-After=rc-local.service plymouth-quit-wait.service systemd-user-sessions.service
-
-# This scope is created by pam_systemd when logging in as the user.
-# This directive is a workaround to a systemd bug, where the setup of the
-# user session by PAM has some race condition, possibly leading to a failure.
-# See README for more details.
-After=session-c1.scope
-
-OnFailure=getty@tty1.service
-
-# Prevent starting on systems without virtual consoles
-ConditionPathExists=/dev/tty0
 
 [Service]
-ExecStart=tinydm-run-session
-User=1000
-Group=1000
-PAMName=login
-WorkingDirectory=~
+Type=simple
+ExecStart=autologin alarm tinydm-run-session
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+TimeoutStopSec=30s
+KeyringMode=shared
 Restart=always
-RestartSec=1s
-
-# A virtual terminal is needed.
-TTYPath=/dev/tty1
-TTYReset=yes
-TTYVHangup=yes
-TTYVTDisallocate=yes
-
-# Fail to start if not controlling the tty.
-StandardInput=tty-fail
-StandardOutput=journal
-StandardError=journal
-
-# Log this user with utmp, letting it show up with commands 'w' and 'who'.
-UtmpIdentifier=tty1
-UtmpMode=user
+RestartSec=1
+StartLimitBurst=5
+StartLimitInterval=30
 
 [Install]
 Alias=display-manager.service


### PR DESCRIPTION
Starting tinydm directly from systemd seems to set up capabilities (specifically CAP_WAKE_ALARM) differently from how the get set up when there's a pam session initialized properly. Bwrap doesn't like this capability being available, which causes a bunch of gtk & flatpak applications to crash.
