### PR TITLE
pkg: danctnix: mobile-config-firefox: upgrade to 4.3.2

### DIFF
--- a/PKGBUILDS/danctnix/mobile-config-firefox/PKGBUILD
+++ b/PKGBUILDS/danctnix/mobile-config-firefox/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Danct12 <danct12@disroot.org>
 pkgname=mobile-config-firefox
-pkgver=4.3.1
+pkgver=4.3.2
 pkgrel=1
 pkgdesc="Mobile and privacy friendly configuration for Firefox"
 arch=(any)
@@ -18,4 +18,4 @@ package() {
   cd "$pkgname-$pkgver"
   make DESTDIR="$pkgdir" install
 }
-sha256sums=('b9c47f687e846b9dc7f17eed040528a9fb21e6f4ce733263dedbb436ac413851')
+sha256sums=('14263d4c154ccca37fc314d53977cf681aa286a1f72275218c9732e651cbc3e1')


### PR DESCRIPTION
Hi, 
thanks for your continued work on Arch Linux for PINE64 devices! 
Here's another bump of mobile-config-firefox:

From the release notes:

Release 4.3.2

Fixes:
* policies.json: No longer hard-remove Google (MR 49)
* tabmenu.css: Fix private browsing mode (MR 51)
* appMenu.css: Adjust appMenu.css for Firefox 127 (MR 50)

I have tested it, and confirmed that it works. Since 127 is already in Arch Linux ARM, this fixes an existing issue with the appMenu and it would be great if it could land quickly!