### PR TITLE
pkg: plasma: plasma-dialer: remove qt6-quickcontrols2 dependency

### DIFF
--- a/PKGBUILDS/plasma/plasma-dialer/PKGBUILD
+++ b/PKGBUILDS/plasma/plasma-dialer/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=plasma-dialer
 pkgver=24.08.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Phone Dialer for Plasma Mobile"
 arch=('aarch64' 'x86_64')
 url="https://community.kde.org/Plasma/Mobile"
@@ -21,7 +21,6 @@ depends=(callaudiod
          kpeople
          libphonenumber
          modemmanager-qt
-         qt6-quickcontrols2
          qtmpris)
 makedepends=(cmake
              extra-cmake-modules


### PR DESCRIPTION
The qt6-quickcontrols2 package has been integrated into the qt6-declarative package. Therefore, it should be removed as a dependency for the plasma-dialer package.

Supporting links:
[https://github.com/qt/qtquickcontrols2?tab=readme-ov-file](https://github.com/qt/qtquickcontrols2?tab=readme-ov-file)
[https://bugreports.qt.io/browse/QTBUG-79454](https://bugreports.qt.io/browse/QTBUG-79454)
[https://wiki.qt.io/QtCS2021_-_Testing_upstream_changes_with_downstream_modules](https://wiki.qt.io/QtCS2021_-_Testing_upstream_changes_with_downstream_modules)

This resolves issue #668 

Once I removed the dependency, plasma-dialer built successfully on my x86_64 machine running Arch Linux.

I have done my best to adhere to the contribution guidelines. Hopefully I did not miss anything.