### PR TITLE
pkg: osk-sdl: fix pinephone osk-sdl regression mesa can't open /usr/lib/gbm/dri_gbm.so error

### DIFF
--- a/PKGBUILDS/danctnix/osk-sdl/PKGBUILD
+++ b/PKGBUILDS/danctnix/osk-sdl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=osk-sdl
 pkgver=0.66
-pkgrel=5
+pkgrel=6
 pkgdesc="SDL2 On-screen Keyboard for FDE"
 arch=(x86_64 armv7h aarch64)
 url="https://gitlab.com/postmarketOS/osk-sdl"
@@ -39,6 +39,6 @@ package() {
 }
 md5sums=('fb608060dea423d221bdfff9a6101624'
          '32b89734fc22fe0dc470e10c3c2e8034'
-         '1b164376ca6c3ee358d5cdd7533a20da'
+         'f5a4ecd937c3b367cab817af62990dbc'
          '8fef952dada64ff63040b5406e71ecac'
          'e6dff50a2f9a27d5de92437394e9cfda')

--- a/PKGBUILDS/danctnix/osk-sdl/osk-sdl-install
+++ b/PKGBUILDS/danctnix/osk-sdl/osk-sdl-install
@@ -39,6 +39,7 @@ build() {
     add_binary /usr/lib/libGL.so.1
     add_binary /usr/lib/libEGL.so.1
     add_binary /usr/lib/libEGL_mesa.so.0
+    add_binary /usr/lib/gbm/dri_gbm.so
 
     [ -f /usr/share/glvnd/egl_vendor.d/50_mesa.json ] && add_file /usr/share/glvnd/egl_vendor.d/50_mesa.json
 


### PR DESCRIPTION
Issue Description:

Pinephone after upgraded the whole system at around 2024-12-14Z, osk-sdl (used to unlock FDE (Full Disk Encryption)) does not start and outputs the following error:
```
MESA-LOADER: failed to open dri: /usr/lib/gbm/dri_gbm.so: cannnot open shared object file:
No such file or directory (search paths /usr/lib/gbm, suffix _gbm)
ERROR: Could not create window/display: EGL not initialized
```

How to reproduce:

Make sure you had a working FDE with osk-sdl in the past, you can use old packages from
http://tardis.tiny-vps.com/aarm/repos/2024/12/03/aarch64/core and http://tardis.tiny-vps.com/aarm/repos/2024/12/03/aarch64/extra archives by adding those links to /etc/pacman.conf to configure FDE to make sure FDE works with old mesa version 1:24.2.7-1. Then you remove those archive url and use default package server and upgrade the whole system, along the way mesa is upgraded to 1:24.3.1-3. To reproduce the error, `sudo mkinitcpio -P` should also be executed. If you had a good FDE with osk-sdl in the past, the following commands should reproduce the error:
```
sudo pacman -Syyu
sudo mkinitcpio -P
sudo reboot
```
Expected behavoir: after reboot, osk-sdl will run normally. Actual behavior: osk-sdl failed to start and outputs errors described in Issue Description.

Fix and reasons:

It seems osk-sdl with new mesa 1:24.3.1-3 somehow requires /usr/lib/gbm/dri_gbm.so and initramfs does not have /usr/lib/gbm/dri_gbm.so. So let's add that to
/usr/lib/initcpio/install/osk-sdl as shown in the commit, then rebuild initramfs with `sudo mkinitcpio -P`, and reboot. Then the issue is fixed.

Note old mesa 1:24.2.7-1 does not have /usr/lib/gbm/dri_gbm.so. I don't know why new mesa 1:24.3.1-3 added /usr/lib/gbm/dri_gbm.so and requires it when using osk-sdl. I don't know what /usr/lib/gbm/dri_gbm.so is for. It seems related to https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31428

Another workaround is to downgrade mesa from 1:24.3.1-3 to 1:24.2.7-1, but I don't think it is a proper way to fix the issue.

Related discussion see https://github.com/dreemurrs-embedded/Pine64-Arch/discussions/682